### PR TITLE
Add UserFixtures with test users for development and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 ### 🚀 Features
 - **Auth:** Login & Registrierung für Restaurant-Besitzer.
 - **Map:** Kartenansicht der Locations.
+- **Data:** `UserFixtures` mit 3 Test-Usern (Admin, verifiziert, unverifiziert) und korrekt gehashten Passwörtern (Symfony PasswordHasher).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The UI language is German/Luxembourgish. The codebase comments (Makefile, templa
 ```
 src/
 ├── Controller/          # Route controllers (attribute-based routing)
-├── DataFixtures/        # Doctrine fixtures (initial restaurant data)
+├── DataFixtures/        # Doctrine fixtures (restaurant data + user test data)
 ├── Entity/              # Doctrine entities (User, Restaurant)
 ├── Repository/          # Doctrine repositories (UserRepository, RestaurantRepository)
 └── Kernel.php           # Symfony kernel
@@ -113,6 +113,14 @@ Routes are defined using PHP attributes (`#[Route]`) on controller methods. Auto
 
 ### Services
 Autowiring and autoconfiguration are enabled by default in `config/services.yaml`. All classes under `src/` are automatically registered as services.
+
+### Data Fixtures
+- Restaurant fixtures: 8 Luxembourg restaurants (`RestaurantFixtures`)
+- User fixtures: 3 test users (`UserFixtures`) with hashed passwords via Symfony PasswordHasher
+  - `admin@endlech.lu` / `admin123` — ROLE_ADMIN, verified
+  - `user@endlech.lu` / `user123` — ROLE_USER, verified
+  - `unverified@endlech.lu` / `unverified123` — ROLE_USER, unverified
+- Fixture references available: `UserFixtures::REFERENCE_ADMIN`, `REFERENCE_USER`, `REFERENCE_UNVERIFIED`
 
 ### Database
 - MySQL 8.0 via Docker Compose (`compose.yaml`) on port 3306

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Hier ist der aktuelle Entwicklungsstand der Plattform.
 - [x] **Frontend Stack:** Tailwind CSS & Webpack Encore Integration.
 - [x] **Datenbank:** Schema für Restaurants & User (MySQL 8.0).
 - [x] **Daten-Seeding:** Initiale Restaurants für Luxemburg via Fixtures.
+- [x] **User-Fixtures:** Test-User (Admin, verifiziert, unverifiziert) für Entwicklung & Tests.
 - [ ] **Authentifizierung:** Login & Registrierung für User.
 
 ### 🍽️ Restaurant Finder

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserFixtures extends Fixture
+{
+    public const REFERENCE_ADMIN = 'user-admin';
+    public const REFERENCE_USER = 'user-test';
+    public const REFERENCE_UNVERIFIED = 'user-unverified';
+
+    public function __construct(
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = [
+            [
+                'name'       => 'Admin User',
+                'email'      => 'admin@endlech.lu',
+                'roles'      => ['ROLE_ADMIN'],
+                'password'   => 'admin123',
+                'isVerified' => true,
+                'reference'  => self::REFERENCE_ADMIN,
+            ],
+            [
+                'name'       => 'Test User',
+                'email'      => 'user@endlech.lu',
+                'roles'      => [],
+                'password'   => 'user123',
+                'isVerified' => true,
+                'reference'  => self::REFERENCE_USER,
+            ],
+            [
+                'name'       => 'Unverified User',
+                'email'      => 'unverified@endlech.lu',
+                'roles'      => [],
+                'password'   => 'unverified123',
+                'isVerified' => false,
+                'reference'  => self::REFERENCE_UNVERIFIED,
+            ],
+        ];
+
+        foreach ($users as $data) {
+            $user = new User();
+            $user->setName($data['name']);
+            $user->setEmail($data['email']);
+            $user->setRoles($data['roles']);
+            $user->setIsVerified($data['isVerified']);
+
+            $hashedPassword = $this->passwordHasher->hashPassword($user, $data['password']);
+            $user->setPassword($hashedPassword);
+
+            $manager->persist($user);
+            $this->addReference($data['reference'], $user);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `UserFixtures` class that seeds the database with three test users for development and testing purposes. The fixture includes users with different roles and verification states, with passwords properly hashed using Symfony's PasswordHasher.

## Key Changes
- **New `UserFixtures` class** (`src/DataFixtures/UserFixtures.php`):
  - Creates 3 test users: Admin (verified), Regular User (verified), and Unverified User
  - Implements proper password hashing via `UserPasswordHasherInterface`
  - Provides fixture references (`REFERENCE_ADMIN`, `REFERENCE_USER`, `REFERENCE_UNVERIFIED`) for use in other fixtures
  - Credentials:
    - `admin@endlech.lu` / `admin123` — ROLE_ADMIN, verified
    - `user@endlech.lu` / `user123` — ROLE_USER, verified
    - `unverified@endlech.lu` / `unverified123` — ROLE_USER, unverified

- **Documentation updates**:
  - Updated `CLAUDE.md` to document the new user fixtures and their credentials
  - Updated `CHANGELOG.md` (German) to reflect the new feature
  - Updated `README.md` to mark user fixtures as completed

## Implementation Details
- Uses constructor injection for `UserPasswordHasherInterface` dependency
- Follows the existing fixture pattern established by `RestaurantFixtures`
- Passwords are hashed at load time, not stored in plaintext
- Fixture references enable other fixtures to reference these users as foreign key relationships

https://claude.ai/code/session_0147g1jbAfmtfAtSTUn7Gs4U