### PR TITLE
Add MIT License to project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 endlech.lu contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "type": "project",
-    "license": "proprietary",
+    "license": "MIT",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "webpack": "^5.74.0",
         "webpack-cli": "^5.1.0"
     },
-    "license": "UNLICENSED",
+    "license": "MIT",
     "private": true,
     "scripts": {
         "dev-server": "encore dev-server",


### PR DESCRIPTION
## Summary
This pull request adds an MIT License to the project and updates the license declarations in configuration files to reflect this change.

## Changes
- Added `LICENSE` file with MIT License text (Copyright 2026 endlech.lu contributors)
- Updated `composer.json` to declare license as "MIT" instead of "proprietary"
- Updated `package.json` to declare license as "MIT" instead of "UNLICENSED"

## Details
The project is now licensed under the MIT License, which is a permissive open-source license that allows users to freely use, modify, and distribute the software with minimal restrictions. All configuration files have been updated to consistently reflect this licensing choice.

https://claude.ai/code/session_01HFKfhjSVpDktjTHaaW7MnR