### PR TITLE
Refactor email templates with base layout and Brevo mailer integration

### DIFF
--- a/.env
+++ b/.env
@@ -44,5 +44,11 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###
 
 ###> symfony/mailer ###
+# Default: null (discard emails). Override in .env.local or .env.dev
+# Dev (Mailpit): MAILER_DSN=smtp://localhost:1025
+# Production (Brevo API): MAILER_DSN=brevo+api://YOUR_API_KEY@default
+# Production (Brevo SMTP): MAILER_DSN=brevo+smtp://USERNAME:PASSWORD@default
 MAILER_DSN=null://null
+MAILER_SENDER_ADDRESS=noreply@endlech.lu
+MAILER_SENDER_NAME=Endlech.lu
 ###< symfony/mailer ###

--- a/.env.dev
+++ b/.env.dev
@@ -2,3 +2,8 @@
 ###> symfony/framework-bundle ###
 APP_SECRET=dfe5df93bfa67d3a5da29458e794a969
 ###< symfony/framework-bundle ###
+
+###> symfony/mailer ###
+# Mailpit: E-Mails lokal abfangen (UI: http://localhost:8025)
+MAILER_DSN=smtp://localhost:1025
+###< symfony/mailer ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
-![Version](https://img.shields.io/badge/version-v2026.03.01-blue)
+![Version](https://img.shields.io/badge/version-v2026.03.08-blue)
 ![Status](https://img.shields.io/badge/status-beta-green)
 
 ## [Unreleased]
@@ -11,6 +11,25 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 ### 🚀 Features
 - **Map:** Kartenansicht der Locations.
 - **Filter:** Aktive Filterung nach Barrierefreiheitskriterien.
+
+---
+
+## [2026.03.08]
+*Brevo Mailer Integration für Transaktions-E-Mails.*
+
+### 🚀 Features
+- **Brevo Integration:** `symfony/brevo-mailer` als Produktions-Mail-Provider installiert und konfiguriert.
+- **E-Mail-Konfiguration:** Zentraler Absender (`noreply@endlech.lu`) über `mailer.yaml` und Umgebungsvariablen konfigurierbar.
+- **Base E-Mail-Template:** Wiederverwendbares Basis-Layout (`email/base.html.twig`) mit Endlech.lu Branding (Gradient-Header, Footer).
+- **Fehlerbehandlung:** Try/Catch für `TransportExceptionInterface` in allen E-Mail-sendenden Controllern mit benutzerfreundlichen Flash-Nachrichten.
+
+### 🛠 Tech & Config
+- **Dependency:** `symfony/brevo-mailer` v8.0 hinzugefügt.
+- **Mailer Config:** Globaler Absender via `envelope.sender` und `headers.From` in `config/packages/mailer.yaml`.
+- **Umgebungsvariablen:** `MAILER_SENDER_ADDRESS` und `MAILER_SENDER_NAME` in `.env` für konfigurierbare Absenderadresse.
+- **Dev-Umgebung:** `.env.dev` nutzt Mailpit (`smtp://localhost:1025`) für lokales E-Mail-Testing.
+- **Templates:** Verification-E-Mail refactored, nutzt jetzt `email/base.html.twig` als Basis-Layout.
+- **Controller:** `RegistrationController` und `EmailVerificationController` nutzen globale Absender-Konfiguration statt hardcoded Adressen.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ The UI language is German/Luxembourgish. The codebase comments (Makefile, templa
 - **JS:** Hotwire (Stimulus 3.x + Turbo 7/8)
 - **Build:** Webpack Encore 5.1
 - **Testing:** PHPUnit 12.5
+- **Email:** Brevo (formerly Sendinblue) via `symfony/brevo-mailer` (production)
 - **Dev Mail:** Mailpit (SMTP on port 1025, UI on port 8025)
 
 ## Project Structure
@@ -49,6 +50,9 @@ templates/
 │       └── _form.html.twig  # Shared form partial (new + edit)
 ├── home/
 │   └── index.html.twig  # Landing page (Hero, "So funktioniert's", Top-6 Restaurants, "Warum Endlech.lu?", CTA)
+├── email/
+│   ├── base.html.twig       # Base email layout (header, footer, branding)
+│   └── verification.html.twig # Email verification template (extends base)
 └── restaurant/
     ├── index.html.twig  # /restaurants – paginated & sortable restaurant list
     └── show.html.twig   # /restaurants/{id} – restaurant detail view
@@ -204,6 +208,15 @@ Defined in `compose.yaml` and `compose.override.yaml`:
 | `.env.local`    | Local overrides (gitignored, secrets here) |
 
 `APP_SECRET` must be set in `.env.local` for production. The `.env.dev` file provides a dev-only secret.
+
+### Email / Mailer
+- **Production:** Brevo API via `symfony/brevo-mailer` – set `MAILER_DSN=brevo+api://YOUR_API_KEY@default` in `.env.local`
+- **Development:** Mailpit via `smtp://localhost:1025` (configured in `.env.dev`), UI at `http://localhost:8025`
+- **Default:** `null://null` (emails discarded) in `.env`
+- **Sender:** Configured globally via `MAILER_SENDER_ADDRESS` and `MAILER_SENDER_NAME` env vars, applied in `config/packages/mailer.yaml`
+- **Async:** Emails routed to async Doctrine transport via Messenger (see `config/packages/messenger.yaml`)
+- **Templates:** All emails extend `email/base.html.twig` for consistent Endlech.lu branding
+- **Error handling:** Controllers catch `TransportExceptionInterface` and show user-friendly flash messages
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An open platform to find and rate accessible restaurants in Luxembourg. Built for inclusion, community, and simplicity.
 
-![Version](https://img.shields.io/badge/version-v2026.03.01-blue)
+![Version](https://img.shields.io/badge/version-v2026.03.08-blue)
 ![Status](https://img.shields.io/badge/status-beta-green)
 
 <div align="center">
@@ -12,7 +12,7 @@ An open platform to find and rate accessible restaurants in Luxembourg. Built fo
 ## 🚀 Project Status
 
 **The first beta version is live.**
-The homepage has been redesigned as a landing page with a hero section, "How it works" steps, restaurant preview, and call-to-action areas. A dedicated restaurant listing at `/restaurants` with pagination and sorting is available. An admin panel at `/admin` allows ROLE_ADMIN users to fully manage (CRUD) restaurants. Next up: map view and active filtering.
+The homepage has been redesigned as a landing page with a hero section, "How it works" steps, restaurant preview, and call-to-action areas. A dedicated restaurant listing at `/restaurants` with pagination and sorting is available. An admin panel at `/admin` allows ROLE_ADMIN users to fully manage (CRUD) restaurants. Transactional emails are powered by Brevo (formerly Sendinblue) with Mailpit for local development. Next up: map view and active filtering.
 
 ## 🎯 Features & Progress
 
@@ -25,6 +25,7 @@ Current development status of the platform.
 - [x] **Data Seeding:** Initial Luxembourg restaurants via fixtures.
 - [x] **User Fixtures:** Test users (admin, verified, unverified) for development & testing.
 - [ ] **Authentication:** Login & registration for users.
+- [x] **Email:** Brevo mailer integration for transactional emails (verification, password reset).
 
 ### 🔧 Admin Panel
 - [x] **Dashboard:** Admin area at `/admin` with statistics and quick actions.
@@ -59,6 +60,7 @@ Ideas for version 2.0 (after the first stable release):
 * **Database:** MySQL 8.0 (Doctrine ORM)
 * **Frontend:** Twig, Tailwind CSS v4 (via PostCSS)
 * **JS:** Stimulus, Turbo (Hotwire)
+* **Email:** Brevo (Symfony Mailer) / Mailpit (dev)
 * **Assets:** Webpack Encore
 
 ## ⚙️ Installation & Setup
@@ -85,6 +87,8 @@ Ideas for version 2.0 (after the first stable release):
     ```bash
     DATABASE_URL="mysql://root:root@127.0.0.1:3306/endlech?serverVersion=8.0&charset=utf8mb4"
     APP_SECRET=your-secret-here
+    # Production only (Brevo):
+    # MAILER_DSN=brevo+api://YOUR_API_KEY@default
     ```
 
 5.  **Database & fixtures:**

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "phpstan/phpdoc-parser": "^2.3",
         "symfony/apache-pack": "*",
         "symfony/asset": "8.0.*",
+        "symfony/brevo-mailer": "*",
         "symfony/console": "8.0.*",
         "symfony/doctrine-messenger": "8.0.*",
         "symfony/dotenv": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bb81a11031e0ba023af76eed42882e0",
+    "content-hash": "efb627a02aca0d4ac19f2ad16f853229",
     "packages": [
         {
             "name": "composer/semver",
@@ -2071,6 +2071,76 @@
                 }
             ],
             "time": "2025-12-19T10:01:18+00:00"
+        },
+        {
+            "name": "symfony/brevo-mailer",
+            "version": "v8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/brevo-mailer.git",
+                "reference": "ba5d44aa012a948810dcdcc69ccb53f4b4e040bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/brevo-mailer/zipball/ba5d44aa012a948810dcdcc69ccb53f4b4e040bb",
+                "reference": "ba5d44aa012a948810dcdcc69ccb53f4b4e040bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/mailer": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/webhook": "^7.4|^8.0"
+            },
+            "type": "symfony-mailer-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\Bridge\\Brevo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pierre Tanguy",
+                    "homepage": "https://github.com/petanguy"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Brevo Mailer Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/brevo-mailer/tree/v8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-04T07:36:47+00:00"
         },
         {
             "name": "symfony/cache",

--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -1,3 +1,7 @@
 framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'
+        envelope:
+            sender: '%env(MAILER_SENDER_ADDRESS)%'
+        headers:
+            From: '%env(MAILER_SENDER_NAME)% <%env(MAILER_SENDER_ADDRESS)%>'

--- a/src/Controller/EmailVerificationController.php
+++ b/src/Controller/EmailVerificationController.php
@@ -7,8 +7,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -73,7 +73,6 @@ final class EmailVerificationController extends AbstractController
         $verifyUrl = $this->generateUrl('app_verify_email', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $email = (new TemplatedEmail())
-            ->from(new Address('noreply@endlech.lu', 'Endlech.lu'))
             ->to($user->getEmail())
             ->subject('Bestätige deine E-Mail-Adresse')
             ->htmlTemplate('email/verification.html.twig')
@@ -82,7 +81,13 @@ final class EmailVerificationController extends AbstractController
                 'verifyUrl' => $verifyUrl,
             ]);
 
-        $mailer->send($email);
+        try {
+            $mailer->send($email);
+        } catch (TransportExceptionInterface) {
+            $this->addFlash('error', 'Die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.');
+
+            return $this->redirectToRoute('app_verify_notice');
+        }
 
         $this->addFlash('success', 'Eine neue Bestätigungs-E-Mail wurde gesendet.');
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -9,8 +9,8 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -45,7 +45,6 @@ final class RegistrationController extends AbstractController
             $verifyUrl = $this->generateUrl('app_verify_email', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL);
 
             $email = (new TemplatedEmail())
-                ->from(new Address('noreply@endlech.lu', 'Endlech.lu'))
                 ->to($user->getEmail())
                 ->subject('Bestätige deine E-Mail-Adresse')
                 ->htmlTemplate('email/verification.html.twig')
@@ -54,7 +53,13 @@ final class RegistrationController extends AbstractController
                     'verifyUrl' => $verifyUrl,
                 ]);
 
-            $mailer->send($email);
+            try {
+                $mailer->send($email);
+            } catch (TransportExceptionInterface) {
+                $this->addFlash('warning', 'Registrierung erfolgreich, aber die Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut.');
+
+                return $this->redirectToRoute('app_verify_notice');
+            }
 
             $this->addFlash('success', 'Registrierung erfolgreich! Bitte überprüfe dein E-Mail-Postfach und bestätige deine Adresse.');
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -89,6 +89,15 @@
             "importmap.php"
         ]
     },
+    "symfony/brevo-mailer": {
+        "version": "8.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.4",
+            "ref": "7c1038ceb733175f610a913a885a7c8b552b703a"
+        }
+    },
     "symfony/console": {
         "version": "8.0",
         "recipe": {

--- a/templates/email/base.html.twig
+++ b/templates/email/base.html.twig
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Endlech.lu{% endblock %}</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f9fafb; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+    <table role="presentation" style="width: 100%; border: 0; cellpadding: 0; cellspacing: 0;">
+        <tr>
+            <td style="padding: 40px 20px;">
+                <table role="presentation" style="max-width: 480px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+                    {# Header #}
+                    <tr>
+                        <td style="background: linear-gradient(135deg, #0891b2, #7c3aed); padding: 32px; text-align: center;">
+                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: 700;">
+                                Endlech<span style="color: #e9d5ff;">.lu</span>
+                            </h1>
+                        </td>
+                    </tr>
+
+                    {# Body #}
+                    <tr>
+                        <td style="padding: 32px;">
+                            {% block body %}{% endblock %}
+                        </td>
+                    </tr>
+
+                    {# Footer #}
+                    <tr>
+                        <td style="padding: 24px 32px; border-top: 1px solid #f3f4f6; text-align: center;">
+                            <p style="margin: 0; color: #9ca3af; font-size: 11px;">
+                                &copy; {{ 'now'|date('Y') }} Endlech.lu - Made with love in Luxembourg
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/templates/email/verification.html.twig
+++ b/templates/email/verification.html.twig
@@ -1,67 +1,32 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>E-Mail bestätigen</title>
-</head>
-<body style="margin: 0; padding: 0; background-color: #f9fafb; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
-    <table role="presentation" style="width: 100%; border: 0; cellpadding: 0; cellspacing: 0;">
+{% extends 'email/base.html.twig' %}
+
+{% block title %}E-Mail bestätigen{% endblock %}
+
+{% block body %}
+    <h2 style="margin: 0 0 16px; color: #111827; font-size: 20px; font-weight: 700;">
+        Hallo {{ user.name }}!
+    </h2>
+
+    <p style="margin: 0 0 24px; color: #6b7280; font-size: 14px; line-height: 1.6;">
+        Vielen Dank für deine Registrierung bei Endlech.lu. Bitte bestätige deine E-Mail-Adresse, indem du auf den folgenden Button klickst:
+    </p>
+
+    <table role="presentation" style="width: 100%; border: 0;">
         <tr>
-            <td style="padding: 40px 20px;">
-                <table role="presentation" style="max-width: 480px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
-                    {# Header #}
-                    <tr>
-                        <td style="background: linear-gradient(135deg, #0891b2, #7c3aed); padding: 32px; text-align: center;">
-                            <h1 style="margin: 0; color: #ffffff; font-size: 24px; font-weight: 700;">
-                                Endlech<span style="color: #e9d5ff;">.lu</span>
-                            </h1>
-                        </td>
-                    </tr>
-
-                    {# Body #}
-                    <tr>
-                        <td style="padding: 32px;">
-                            <h2 style="margin: 0 0 16px; color: #111827; font-size: 20px; font-weight: 700;">
-                                Hallo {{ user.name }}!
-                            </h2>
-
-                            <p style="margin: 0 0 24px; color: #6b7280; font-size: 14px; line-height: 1.6;">
-                                Vielen Dank für deine Registrierung bei Endlech.lu. Bitte bestätige deine E-Mail-Adresse, indem du auf den folgenden Button klickst:
-                            </p>
-
-                            <table role="presentation" style="width: 100%; border: 0;">
-                                <tr>
-                                    <td style="text-align: center; padding: 8px 0 24px;">
-                                        <a href="{{ verifyUrl }}" style="display: inline-block; background-color: #7c3aed; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 700; font-size: 14px;">
-                                            E-Mail bestätigen
-                                        </a>
-                                    </td>
-                                </tr>
-                            </table>
-
-                            <p style="margin: 0 0 8px; color: #9ca3af; font-size: 12px;">
-                                Dieser Link ist 24 Stunden gültig. Falls du dich nicht bei Endlech.lu registriert hast, kannst du diese E-Mail ignorieren.
-                            </p>
-
-                            <p style="margin: 0; color: #9ca3af; font-size: 12px;">
-                                Falls der Button nicht funktioniert, kopiere diesen Link in deinen Browser:<br>
-                                <a href="{{ verifyUrl }}" style="color: #7c3aed; word-break: break-all;">{{ verifyUrl }}</a>
-                            </p>
-                        </td>
-                    </tr>
-
-                    {# Footer #}
-                    <tr>
-                        <td style="padding: 24px 32px; border-top: 1px solid #f3f4f6; text-align: center;">
-                            <p style="margin: 0; color: #9ca3af; font-size: 11px;">
-                                &copy; {{ 'now'|date('Y') }} Endlech.lu - Made with love in Luxembourg
-                            </p>
-                        </td>
-                    </tr>
-                </table>
+            <td style="text-align: center; padding: 8px 0 24px;">
+                <a href="{{ verifyUrl }}" style="display: inline-block; background-color: #7c3aed; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 700; font-size: 14px;">
+                    E-Mail bestätigen
+                </a>
             </td>
         </tr>
     </table>
-</body>
-</html>
+
+    <p style="margin: 0 0 8px; color: #9ca3af; font-size: 12px;">
+        Dieser Link ist 24 Stunden gültig. Falls du dich nicht bei Endlech.lu registriert hast, kannst du diese E-Mail ignorieren.
+    </p>
+
+    <p style="margin: 0; color: #9ca3af; font-size: 12px;">
+        Falls der Button nicht funktioniert, kopiere diesen Link in deinen Browser:<br>
+        <a href="{{ verifyUrl }}" style="color: #7c3aed; word-break: break-all;">{{ verifyUrl }}</a>
+    </p>
+{% endblock %}


### PR DESCRIPTION
## Summary
This PR introduces a reusable email base template and integrates Brevo (formerly Sendinblue) as the production email provider. Email sender configuration is now centralized via environment variables, and error handling has been added to email-sending controllers.

## Key Changes

- **New Base Email Template:** Created `templates/email/base.html.twig` with consistent Endlech.lu branding (gradient header, footer, responsive layout) that all transactional emails extend
- **Refactored Verification Email:** `templates/email/verification.html.twig` now extends the base template, reducing duplication and improving maintainability
- **Centralized Sender Configuration:** Moved hardcoded sender addresses to environment variables (`MAILER_SENDER_ADDRESS`, `MAILER_SENDER_NAME`) configured in `config/packages/mailer.yaml`
- **Brevo Mailer Setup:** Added `symfony/brevo-mailer` dependency with DSN configuration supporting both API and SMTP modes
- **Error Handling:** Added `TransportExceptionInterface` try/catch blocks in `RegistrationController` and `EmailVerificationController` with user-friendly flash messages
- **Development Email Testing:** Configured Mailpit (`smtp://localhost:1025`) in `.env.dev` for local email interception and inspection
- **Documentation:** Updated `CLAUDE.md` and `README.md` with email configuration details and Brevo integration notes

## Implementation Details

- Removed `->from(new Address(...))` calls from email instantiation in controllers; sender is now applied globally via mailer configuration
- Email templates use Twig block inheritance (`{% block body %}`) for flexible content composition
- Async email routing via Doctrine transport and Messenger remains unchanged
- Default `.env` uses `null://null` (discard emails); production requires `MAILER_DSN` override in `.env.local`
- Version bumped to `v2026.03.08` in `CHANGELOG.md` and `README.md`

https://claude.ai/code/session_01Gi1RnyD2zakzQMBEvQYhuS