### PR TITLE
Add verified badge for restaurants (issue #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ---
 
+## [2026.03.08c] – Verifiziertes Lokal
+*Blaues Verifikations-Badge für vom Endlech.lu-Team geprüfte Restaurants.*
+
+### 🚀 Features
+- **Verifikations-Badge:** Blauer Haken (Cyan-600) für verifizierte Restaurants auf Karte und Detailseite.
+- **Tooltip:** „Von Endlech.lu persönlich vor Ort geprüft" via Browser-Tooltip.
+- **Filter:** Listenansicht filtert nach „Nur verifizierte Lokale" (?verified=1).
+- **Admin:** Verifikations-Checkbox im Bearbeitungsformular mit Auto-Stamping von Datum + Admin-User.
+- **Admin:** Quick-Toggle-Button in der Restaurants-Übersicht (verifiziert/unverifiziert).
+- **Admin:** Stat-Card „Verifizierte Lokale" im Dashboard.
+
+### 🛠 Tech & Config
+- **Entity:** `isVerified`, `verifiedAt`, `verifiedBy` zur `Restaurant`-Entity hinzugefügt.
+- **Migration:** `Version20260308100000` – fügt `is_verified`, `verified_at`, `verified_by_id` zur `restaurant`-Tabelle hinzu.
+- **Route:** `admin_restaurant_toggle_verified` POST `/admin/restaurants/{id}/verifizieren`.
+- **Partial:** `templates/partials/_verified_badge.html.twig` – wiederverwendbares Badge-Template.
+- **Fixtures:** 3 Restaurants als verifiziert markiert (Pizzeria Bella Vista, Sushi Zen, Green Bowl).
+
+---
+
 ## [2026.03.08b] – Zahlungsmethoden
 *Zahlungsmethoden pro Restaurant (Bargeld, Karte, Payconiq).*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,15 +144,17 @@ Autowiring and autoconfiguration are enabled by default in `config/services.yaml
 | `admin_restaurant_new`  | `/admin/restaurants/neu` | `AdminRestaurantController::new()` |
 | `admin_restaurant_edit` | `/admin/restaurants/{id}/bearbeiten` | `AdminRestaurantController::edit()` |
 | `admin_restaurant_delete`| `/admin/restaurants/{id}/loeschen` | `AdminRestaurantController::delete()` |
+| `admin_restaurant_toggle_verified`| `/admin/restaurants/{id}/verifizieren` | `AdminRestaurantController::toggleVerified()` |
 
 `/restaurants` accepts query params:
 - `?sort=rating` (default) – sorted by rating DESC
 - `?sort=name` – sorted A–Z
 - `?sort=newest` – sorted by `createdAt` DESC
 - `?page=N` – page number (6 items per page, uses Doctrine `Paginator`)
+- `?verified=1` – filter to verified restaurants only
 
 ### Data Fixtures
-- Restaurant fixtures: 11 Luxembourg restaurants (`RestaurantFixtures`); each restaurant has accessibility fields (`isWheelchairAccessible`, `hasAccessibleToilet`, `allowsAssistanceDogs`, `hasBrightLighting`) and payment method fields (`acceptsCash`, `acceptsCard`, `acceptsPayconiq`)
+- Restaurant fixtures: 11 Luxembourg restaurants (`RestaurantFixtures`); each restaurant has accessibility fields (`isWheelchairAccessible`, `hasAccessibleToilet`, `allowsAssistanceDogs`, `hasBrightLighting`), payment method fields (`acceptsCash`, `acceptsCard`, `acceptsPayconiq`), and verification fields (`isVerified`, `verifiedAt`, `verifiedBy`). 3 restaurants are verified: Pizzeria Bella Vista, Sushi Zen, Green Bowl.
 - User fixtures: 3 test users (`UserFixtures`) with hashed passwords via Symfony PasswordHasher
   - `admin@endlech.lu` / `admin123` — ROLE_ADMIN, verified
   - `user@endlech.lu` / `user123` — ROLE_USER, verified

--- a/migrations/Version20260308100000.php
+++ b/migrations/Version20260308100000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260308100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add verification fields to restaurant table (isVerified, verifiedAt, verifiedBy)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE restaurant ADD is_verified TINYINT(1) NOT NULL DEFAULT 0, ADD verified_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD verified_by_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE restaurant ADD CONSTRAINT FK_restaurant_verified_by FOREIGN KEY (verified_by_id) REFERENCES `user` (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_restaurant_verified_by ON restaurant (verified_by_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE restaurant DROP FOREIGN KEY FK_restaurant_verified_by');
+        $this->addSql('DROP INDEX IDX_restaurant_verified_by ON restaurant');
+        $this->addSql('ALTER TABLE restaurant DROP is_verified, DROP verified_at, DROP verified_by_id');
+    }
+}

--- a/src/Controller/AdminRestaurantController.php
+++ b/src/Controller/AdminRestaurantController.php
@@ -23,6 +23,7 @@ final class AdminRestaurantController extends AbstractController
         return $this->render('admin/dashboard.html.twig', [
             'restaurantCount' => $restaurantRepository->count(),
             'pendingSuggestionCount' => $suggestionRepository->countPending(),
+            'verifiedCount' => $restaurantRepository->countVerified(),
         ]);
     }
 
@@ -58,10 +59,20 @@ final class AdminRestaurantController extends AbstractController
     #[Route('/restaurants/{id}/bearbeiten', name: 'admin_restaurant_edit', requirements: ['id' => '\d+'], methods: ['GET', 'POST'])]
     public function edit(Restaurant $restaurant, Request $request, EntityManagerInterface $entityManager): Response
     {
+        $wasVerified = $restaurant->isVerified();
         $form = $this->createForm(RestaurantType::class, $restaurant);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $isNowVerified = $restaurant->isVerified();
+            if ($isNowVerified && !$wasVerified) {
+                $restaurant->setVerifiedAt(new \DateTimeImmutable());
+                $restaurant->setVerifiedBy($this->getUser());
+            } elseif (!$isNowVerified && $wasVerified) {
+                $restaurant->setVerifiedAt(null);
+                $restaurant->setVerifiedBy(null);
+            }
+
             $entityManager->flush();
 
             $this->addFlash('success', 'Restaurant erfolgreich aktualisiert.');
@@ -73,6 +84,29 @@ final class AdminRestaurantController extends AbstractController
             'restaurant' => $restaurant,
             'form' => $form,
         ]);
+    }
+
+    #[Route('/restaurants/{id}/verifizieren', name: 'admin_restaurant_toggle_verified', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function toggleVerified(Restaurant $restaurant, Request $request, EntityManagerInterface $em): Response
+    {
+        if ($this->isCsrfTokenValid('toggle-verified-' . $restaurant->getId(), $request->request->getString('_token'))) {
+            if ($restaurant->isVerified()) {
+                $restaurant->setIsVerified(false);
+                $restaurant->setVerifiedAt(null);
+                $restaurant->setVerifiedBy(null);
+                $this->addFlash('success', 'Verifizierung für „' . $restaurant->getName() . '" aufgehoben.');
+            } else {
+                $restaurant->setIsVerified(true);
+                $restaurant->setVerifiedAt(new \DateTimeImmutable());
+                $restaurant->setVerifiedBy($this->getUser());
+                $this->addFlash('success', '„' . $restaurant->getName() . '" als verifiziert markiert.');
+            }
+            $em->flush();
+        } else {
+            $this->addFlash('error', 'Ungültiges CSRF-Token. Bitte versuche es erneut.');
+        }
+
+        return $this->redirectToRoute('admin_restaurant_index');
     }
 
     #[Route('/restaurants/{id}/loeschen', name: 'admin_restaurant_delete', requirements: ['id' => '\d+'], methods: ['POST'])]

--- a/src/Controller/RestaurantController.php
+++ b/src/Controller/RestaurantController.php
@@ -22,8 +22,9 @@ final class RestaurantController extends AbstractController
         }
 
         $page = max(1, $request->query->getInt('page', 1));
+        $verifiedOnly = $request->query->getBoolean('verified', false);
 
-        $paginator = $restaurantRepository->findPaginated($sort, $page, self::LIMIT);
+        $paginator = $restaurantRepository->findPaginated($sort, $page, self::LIMIT, $verifiedOnly);
         $total = count($paginator);
         $lastPage = max(1, (int) ceil($total / self::LIMIT));
 
@@ -33,6 +34,7 @@ final class RestaurantController extends AbstractController
             'lastPage' => $lastPage,
             'total' => $total,
             'sort' => $sort,
+            'verifiedOnly' => $verifiedOnly,
         ]);
     }
 

--- a/src/DataFixtures/RestaurantFixtures.php
+++ b/src/DataFixtures/RestaurantFixtures.php
@@ -3,11 +3,18 @@
 namespace App\DataFixtures;
 
 use App\Entity\Restaurant;
+use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class RestaurantFixtures extends Fixture
+class RestaurantFixtures extends Fixture implements DependentFixtureInterface
 {
+    public function getDependencies(): array
+    {
+        return [UserFixtures::class];
+    }
+
     public function load(ObjectManager $manager): void
     {
         $restaurants = [
@@ -26,6 +33,7 @@ class RestaurantFixtures extends Fixture
                 'acceptsCard'            => true,
                 'acceptsPayconiq'        => true,
                 'accessibilityNotes'     => ['ok:Eingang stufenlos', 'ok:WC Tür > 90cm'],
+                'isVerified'             => true,
             ],
             [
                 'name'                   => 'Umami Corner',
@@ -122,6 +130,7 @@ class RestaurantFixtures extends Fixture
                 'acceptsCard'            => true,
                 'acceptsPayconiq'        => true,
                 'accessibilityNotes'     => ['ok:Vollständig barrierefrei', 'ok:Rollstuhlrampe vorhanden', 'ok:Barrierefreies WC'],
+                'isVerified'             => true,
             ],
             [
                 'name'                   => 'Wäinhaus am Markt',
@@ -170,6 +179,7 @@ class RestaurantFixtures extends Fixture
                 'acceptsCard'            => true,
                 'acceptsPayconiq'        => true,
                 'accessibilityNotes'     => ['ok:Vollständig barrierefrei', 'ok:Induktive Höranlage vorhanden'],
+                'isVerified'             => true,
             ],
             [
                 'name'                   => 'Brasserie du Grund',
@@ -205,6 +215,14 @@ class RestaurantFixtures extends Fixture
             $restaurant->setAcceptsCard($data['acceptsCard']);
             $restaurant->setAcceptsPayconiq($data['acceptsPayconiq']);
             $restaurant->setAccessibilityNotes($data['accessibilityNotes']);
+
+            $isVerified = $data['isVerified'] ?? false;
+            $restaurant->setIsVerified($isVerified);
+            if ($isVerified) {
+                $restaurant->setVerifiedAt(new \DateTimeImmutable('2026-01-15'));
+                $restaurant->setVerifiedBy($this->getReference(UserFixtures::REFERENCE_ADMIN, User::class));
+            }
+
             $manager->persist($restaurant);
         }
 

--- a/src/Entity/Restaurant.php
+++ b/src/Entity/Restaurant.php
@@ -52,6 +52,16 @@ class Restaurant
     #[ORM\Column]
     private bool $acceptsPayconiq = false;
 
+    #[ORM\Column]
+    private bool $isVerified = false;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $verifiedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $verifiedBy = null;
+
     /** @var list<string> */
     #[ORM\Column(type: 'json')]
     private array $accessibilityNotes = [];
@@ -242,5 +252,41 @@ class Restaurant
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->isVerified;
+    }
+
+    public function setIsVerified(bool $isVerified): static
+    {
+        $this->isVerified = $isVerified;
+
+        return $this;
+    }
+
+    public function getVerifiedAt(): ?\DateTimeImmutable
+    {
+        return $this->verifiedAt;
+    }
+
+    public function setVerifiedAt(?\DateTimeImmutable $verifiedAt): static
+    {
+        $this->verifiedAt = $verifiedAt;
+
+        return $this;
+    }
+
+    public function getVerifiedBy(): ?User
+    {
+        return $this->verifiedBy;
+    }
+
+    public function setVerifiedBy(?User $verifiedBy): static
+    {
+        $this->verifiedBy = $verifiedBy;
+
+        return $this;
     }
 }

--- a/src/Form/RestaurantType.php
+++ b/src/Form/RestaurantType.php
@@ -69,6 +69,10 @@ class RestaurantType extends AbstractType
                 'label' => 'Geöffnet',
                 'required' => false,
             ])
+            ->add('isVerified', CheckboxType::class, [
+                'label'    => 'Verifiziertes Lokal (von Endlech.lu geprüft)',
+                'required' => false,
+            ])
             ->add('isWheelchairAccessible', CheckboxType::class, [
                 'label' => 'Rollstuhlgerecht',
                 'required' => false,

--- a/src/Repository/RestaurantRepository.php
+++ b/src/Repository/RestaurantRepository.php
@@ -30,9 +30,13 @@ class RestaurantRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findPaginated(string $sort = 'rating', int $page = 1, int $limit = 6): Paginator
+    public function findPaginated(string $sort = 'rating', int $page = 1, int $limit = 6, bool $verifiedOnly = false): Paginator
     {
         $qb = $this->createQueryBuilder('r');
+
+        if ($verifiedOnly) {
+            $qb->andWhere('r.isVerified = :verified')->setParameter('verified', true);
+        }
 
         match ($sort) {
             'name' => $qb->orderBy('r.name', 'ASC'),
@@ -44,5 +48,15 @@ class RestaurantRepository extends ServiceEntityRepository
             ->setMaxResults($limit);
 
         return new Paginator($qb);
+    }
+
+    public function countVerified(): int
+    {
+        return (int) $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->where('r.isVerified = :verified')
+            ->setParameter('verified', true)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 }

--- a/templates/admin/dashboard.html.twig
+++ b/templates/admin/dashboard.html.twig
@@ -23,6 +23,21 @@
         </div>
     </div>
 
+    {# Verifizierte Lokale-Karte #}
+    <div class="bg-white rounded-xl shadow-sm border border-cyan-100 p-6">
+        <div class="flex items-center gap-4">
+            <div class="bg-cyan-50 text-cyan-600 p-3 rounded-lg text-2xl">
+                <svg class="w-7 h-7" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0 1 12 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 0 1 3.498 1.307 4.491 4.491 0 0 1 1.307 3.497A4.49 4.49 0 0 1 21.75 12a4.49 4.49 0 0 1-1.549 3.397 4.491 4.491 0 0 1-1.307 3.497 4.491 4.491 0 0 1-3.497 1.307A4.49 4.49 0 0 1 12 21.75a4.49 4.49 0 0 1-3.397-1.549 4.49 4.49 0 0 1-3.498-1.306 4.491 4.491 0 0 1-1.307-3.498A4.49 4.49 0 0 1 2.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 0 1 1.307-3.497 4.49 4.49 0 0 1 3.497-1.307Zm7.007 6.387a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/>
+                </svg>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Verifizierte Lokale</p>
+                <p class="text-3xl font-bold text-cyan-700">{{ verifiedCount }}</p>
+            </div>
+        </div>
+    </div>
+
     {# Vorschläge-Karte #}
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 {{ pendingSuggestionCount > 0 ? 'border-amber-300' : '' }}">
         <div class="flex items-center gap-4">

--- a/templates/admin/restaurant/_form.html.twig
+++ b/templates/admin/restaurant/_form.html.twig
@@ -49,6 +49,10 @@
             {{ form_widget(form.isOpen, {'attr': {'class': 'rounded text-purple-600 focus:ring-purple-500 border-gray-300'}}) }}
             <span class="text-sm text-gray-600 group-hover:text-purple-700">Restaurant ist geöffnet</span>
         </label>
+        <label class="flex items-center gap-3 cursor-pointer group mt-3">
+            {{ form_widget(form.isVerified, {'attr': {'class': 'rounded text-cyan-600 focus:ring-cyan-500 border-gray-300'}}) }}
+            <span class="text-sm text-gray-600 group-hover:text-cyan-700">✓ Verifiziertes Lokal (von Endlech.lu persönlich geprüft)</span>
+        </label>
     </fieldset>
 
     {# --- Barrierefreiheit --- #}

--- a/templates/admin/restaurant/index.html.twig
+++ b/templates/admin/restaurant/index.html.twig
@@ -23,6 +23,7 @@
                     <th class="px-4 py-3 font-semibold text-gray-600">Bewertung</th>
                     <th class="px-4 py-3 font-semibold text-gray-600">Status</th>
                     <th class="px-4 py-3 font-semibold text-gray-600">Barrierefreiheit</th>
+                    <th class="px-4 py-3 font-semibold text-gray-600">Verifiziert</th>
                     <th class="px-4 py-3 font-semibold text-gray-600 text-right">Aktionen</th>
                 </tr>
             </thead>
@@ -57,6 +58,18 @@
                             {% if restaurant.hasBrightLighting %}<span title="Helle Beleuchtung">💡</span>{% endif %}
                         </div>
                     </td>
+                    <td class="px-4 py-3">
+                        <form method="post" action="{{ path('admin_restaurant_toggle_verified', {id: restaurant.id}) }}">
+                            <input type="hidden" name="_token" value="{{ csrf_token('toggle-verified-' ~ restaurant.id) }}">
+                            <button type="submit"
+                                    title="{{ restaurant.isVerified ? 'Verifizierung aufheben' : 'Als verifiziert markieren' }}"
+                                    class="p-1.5 rounded-lg transition {{ restaurant.isVerified ? 'text-cyan-600 bg-cyan-50 hover:bg-red-50 hover:text-red-500' : 'text-gray-300 hover:bg-cyan-50 hover:text-cyan-600' }}">
+                                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0 1 12 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 0 1 3.498 1.307 4.491 4.491 0 0 1 1.307 3.497A4.49 4.49 0 0 1 21.75 12a4.49 4.49 0 0 1-1.549 3.397 4.491 4.491 0 0 1-1.307 3.497 4.491 4.491 0 0 1-3.497 1.307A4.49 4.49 0 0 1 12 21.75a4.49 4.49 0 0 1-3.397-1.549 4.49 4.49 0 0 1-3.498-1.306 4.491 4.491 0 0 1-1.307-3.498A4.49 4.49 0 0 1 2.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 0 1 1.307-3.497 4.49 4.49 0 0 1 3.497-1.307Zm7.007 6.387a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/>
+                                </svg>
+                            </button>
+                        </form>
+                    </td>
                     <td class="px-4 py-3 text-right">
                         <div class="flex justify-end gap-2">
                             <a href="{{ path('admin_restaurant_edit', {id: restaurant.id}) }}"
@@ -75,7 +88,7 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="8" class="px-4 py-8 text-center text-gray-400">
+                    <td colspan="9" class="px-4 py-8 text-center text-gray-400">
                         Noch keine Restaurants vorhanden.
                     </td>
                 </tr>

--- a/templates/partials/_verified_badge.html.twig
+++ b/templates/partials/_verified_badge.html.twig
@@ -1,0 +1,23 @@
+{# Verifikations-Badge für verifizierte Restaurants #}
+{# Parameter: restaurant, size ('sm' Standard, 'lg' für Detailseite) #}
+
+{% if restaurant.isVerified %}
+    {% set size = size ?? 'sm' %}
+    {% if size == 'lg' %}
+        <span class="inline-flex items-center gap-1.5 bg-cyan-50 text-cyan-700 border border-cyan-200 rounded-full px-3 py-1 text-sm font-semibold"
+              title="Von Endlech.lu persönlich vor Ort geprüft">
+            <svg class="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0 1 12 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 0 1 3.498 1.307 4.491 4.491 0 0 1 1.307 3.497A4.49 4.49 0 0 1 21.75 12a4.49 4.49 0 0 1-1.549 3.397 4.491 4.491 0 0 1-1.307 3.497 4.491 4.491 0 0 1-3.497 1.307A4.49 4.49 0 0 1 12 21.75a4.49 4.49 0 0 1-3.397-1.549 4.49 4.49 0 0 1-3.498-1.306 4.491 4.491 0 0 1-1.307-3.498A4.49 4.49 0 0 1 2.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 0 1 1.307-3.497 4.49 4.49 0 0 1 3.497-1.307Zm7.007 6.387a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/>
+            </svg>
+            Verifiziertes Lokal
+        </span>
+    {% else %}
+        <span class="inline-flex items-center gap-1 bg-cyan-50 text-cyan-700 border border-cyan-200 rounded-full px-2 py-0.5 text-xs font-semibold"
+              title="Von Endlech.lu persönlich vor Ort geprüft">
+            <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0 1 12 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 0 1 3.498 1.307 4.491 4.491 0 0 1 1.307 3.497A4.49 4.49 0 0 1 21.75 12a4.49 4.49 0 0 1-1.549 3.397 4.491 4.491 0 0 1-1.307 3.497 4.491 4.491 0 0 1-3.497 1.307A4.49 4.49 0 0 1 12 21.75a4.49 4.49 0 0 1-3.397-1.549 4.49 4.49 0 0 1-3.498-1.306 4.491 4.491 0 0 1-1.307-3.498A4.49 4.49 0 0 1 2.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 0 1 1.307-3.497 4.49 4.49 0 0 1 3.497-1.307Zm7.007 6.387a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/>
+            </svg>
+            Verifiziert
+        </span>
+    {% endif %}
+{% endif %}

--- a/templates/restaurant/index.html.twig
+++ b/templates/restaurant/index.html.twig
@@ -32,6 +32,16 @@
                             </div>
 
                             <div class="mb-6">
+                                <label class="block text-sm font-semibold text-gray-700 mb-3">Qualität</label>
+                                <label class="flex items-center gap-3 cursor-pointer group">
+                                    <input type="checkbox" name="verified" value="1"
+                                           class="rounded text-cyan-600 focus:ring-cyan-500 border-gray-300"
+                                           {{ verifiedOnly ? 'checked' : '' }}>
+                                    <span class="text-sm text-gray-600 group-hover:text-cyan-700">✓ Nur verifizierte Lokale</span>
+                                </label>
+                            </div>
+
+                            <div class="mb-6">
                                 <label class="block text-sm font-semibold text-gray-700 mb-3">Bedürfnisse</label>
 
                                 <label class="flex items-center gap-3 mb-2 cursor-pointer group">
@@ -69,15 +79,15 @@
                     <div class="flex justify-between items-center mb-6">
                         <h2 class="text-xl font-bold text-gray-800">{{ total }} Ergebnisse gefunden</h2>
                         <div class="flex items-center gap-2">
-                            <a href="{{ path('app_restaurant_index', {sort: 'rating', page: 1}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'rating', page: 1, verified: verifiedOnly ? 1 : null}) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'rating' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 Beste Bewertung
                             </a>
-                            <a href="{{ path('app_restaurant_index', {sort: 'name', page: 1}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'name', page: 1, verified: verifiedOnly ? 1 : null}) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'name' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 A – Z
                             </a>
-                            <a href="{{ path('app_restaurant_index', {sort: 'newest', page: 1}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'newest', page: 1, verified: verifiedOnly ? 1 : null}) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'newest' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 Neueste
                             </a>
@@ -100,7 +110,10 @@
                                 <div class="p-5 flex-grow">
                                     <div class="flex justify-between items-start">
                                         <div>
-                                            <h3 class="text-lg font-bold text-gray-900 group-hover:text-purple-700 transition">{{ restaurant.name }}</h3>
+                                            <div class="flex items-center gap-2 flex-wrap">
+                                                <h3 class="text-lg font-bold text-gray-900 group-hover:text-purple-700 transition">{{ restaurant.name }}</h3>
+                                                {% include 'partials/_verified_badge.html.twig' with {restaurant: restaurant} %}
+                                            </div>
                                             <p class="text-sm text-gray-500">{{ restaurant.city }} &bull; {{ restaurant.cuisine }}</p>
                                         </div>
                                         {% if restaurant.rating is not null %}
@@ -160,21 +173,21 @@
                     {% if lastPage > 1 %}
                         <nav class="flex justify-center items-center gap-2 mt-10" aria-label="Seitennavigation">
                             {% if currentPage > 1 %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage - 1}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage - 1, verified: verifiedOnly ? 1 : null}) }}"
                                    class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 hover:border-purple-400 transition text-sm">
                                     ← Zurück
                                 </a>
                             {% endif %}
 
                             {% for p in 1..lastPage %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: p}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: p, verified: verifiedOnly ? 1 : null}) }}"
                                    class="px-4 py-2 rounded-lg border text-sm transition {{ p == currentPage ? 'bg-purple-600 text-white border-purple-600 font-bold' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                     {{ p }}
                                 </a>
                             {% endfor %}
 
                             {% if currentPage < lastPage %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage + 1}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage + 1, verified: verifiedOnly ? 1 : null}) }}"
                                    class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 hover:border-purple-400 transition text-sm">
                                     Weiter →
                                 </a>

--- a/templates/restaurant/show.html.twig
+++ b/templates/restaurant/show.html.twig
@@ -12,11 +12,14 @@
                 <div class="text-7xl mb-4">{{ restaurant.emoji }}</div>
                 <h1 class="text-3xl font-bold mb-2">{{ restaurant.name }}</h1>
                 <p class="text-cyan-100 text-lg">{{ restaurant.city }} &bull; {{ restaurant.cuisine }}</p>
-                {% if restaurant.isOpen %}
-                    <span class="inline-block mt-4 bg-green-500 text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-sm">Geöffnet</span>
-                {% else %}
-                    <span class="inline-block mt-4 bg-red-500 text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-sm">Geschlossen</span>
-                {% endif %}
+                <div class="flex items-center justify-center gap-3 mt-4 flex-wrap">
+                    {% if restaurant.isOpen %}
+                        <span class="inline-block bg-green-500 text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-sm">Geöffnet</span>
+                    {% else %}
+                        <span class="inline-block bg-red-500 text-white text-sm font-bold px-4 py-1.5 rounded-full shadow-sm">Geschlossen</span>
+                    {% endif %}
+                    {% include 'partials/_verified_badge.html.twig' with {restaurant: restaurant, size: 'lg'} %}
+                </div>
             </div>
         </div>
 
@@ -27,6 +30,22 @@
             <a href="{{ path('app_restaurant_index') }}" class="inline-flex items-center gap-2 text-purple-600 hover:text-purple-800 font-semibold mb-8 transition">
                 ← Zurück zur Liste
             </a>
+
+            {# --- VERIFIZIERUNGS-INFO-KARTE --- #}
+            {% if restaurant.isVerified %}
+            <div class="bg-cyan-50 rounded-xl border border-cyan-200 p-5 mb-6 flex items-start gap-4">
+                <svg class="w-6 h-6 text-cyan-600 shrink-0 mt-0.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M8.603 3.799A4.49 4.49 0 0 1 12 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 0 1 3.498 1.307 4.491 4.491 0 0 1 1.307 3.497A4.49 4.49 0 0 1 21.75 12a4.49 4.49 0 0 1-1.549 3.397 4.491 4.491 0 0 1-1.307 3.497 4.491 4.491 0 0 1-3.497 1.307A4.49 4.49 0 0 1 12 21.75a4.49 4.49 0 0 1-3.397-1.549 4.49 4.49 0 0 1-3.498-1.306 4.491 4.491 0 0 1-1.307-3.498A4.49 4.49 0 0 1 2.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 0 1 1.307-3.497 4.49 4.49 0 0 1 3.497-1.307Zm7.007 6.387a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/>
+                </svg>
+                <div>
+                    <p class="text-sm font-bold text-cyan-800">Von Endlech.lu persönlich vor Ort geprüft</p>
+                    <p class="text-xs text-cyan-600 mt-0.5">
+                        Die Barrierefreiheitsangaben dieses Lokals wurden von unserem Team persönlich verifiziert.
+                        {% if restaurant.verifiedAt is not null %}Geprüft am {{ restaurant.verifiedAt|date('d.m.Y') }}.{% endif %}
+                    </p>
+                </div>
+            </div>
+            {% endif %}
 
             {# --- BEWERTUNG --- #}
             {% if restaurant.rating is not null %}


### PR DESCRIPTION
## Summary

- **Verifikations-Badge:** Blauer Haken (Cyan-600) für vom Endlech.lu-Team geprüfte Restaurants – sichtbar auf Karte und Detailseite.
- **Filter:** `/restaurants?verified=1` zeigt nur verifizierte Lokale; Filter-Checkbox in der Sidebar.
- **Admin:** Verifikations-Checkbox im Bearbeitungsformular (mit Auto-Stamping von Datum + Admin-User), Quick-Toggle in der Übersicht, Stat-Card im Dashboard.
- **Migration:** `Version20260308100000` fügt `is_verified`, `verified_at`, `verified_by_id` zur `restaurant`-Tabelle hinzu.
- **Fixtures:** 3 Restaurants als verifiziert markiert (Pizzeria Bella Vista, Sushi Zen, Green Bowl).

Closes #30

## Test plan

- [ ] `make db` – Migration ausführen
- [ ] `make fixtures` – 3 verifizierte Restaurants laden
- [ ] `/restaurants` – Badge auf Bella Vista, Sushi Zen, Green Bowl sichtbar
- [ ] `/restaurants?verified=1` – nur 3 Restaurants angezeigt
- [ ] `/restaurants/{id}` für verifiziertes Restaurant – Info-Karte + Hero-Badge
- [ ] `/admin/restaurants` – neue Spalte mit Quick-Toggle; Hover-Effekt (Cyan → Rot)
- [ ] `/admin/restaurants/{id}/bearbeiten` – isVerified-Checkbox; nach Speichern: `verifiedAt` gesetzt
- [ ] `/admin` – Dashboard zeigt „3 Verifizierte Lokale"

🤖 Generated with [Claude Code](https://claude.com/claude-code)