### PR TITLE
Add filter functionality for restaurants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ### 🚀 Features
 - **Map:** Kartenansicht der Locations.
-- **Filter:** Aktive Filterung nach Barrierefreiheitskriterien.
+
+---
+
+## [2026.03.08d] – Filterfunktion für Lokale
+
+### 🚀 Features
+- **Barrierefreiheits-Filter:** Checkboxen für ♿ Rollstuhlgerecht, 🚻 Barrierefreies WC, 🐕 Assistenzhund, 💡 Helle Beleuchtung.
+- **Status-Filter:** „Nur geöffnete Lokale" Checkbox.
+- **Ort-Filter:** Freitext-Suche nach Stadt (LIKE).
+- **Küchen-Filter:** Freitext-Suche nach Küchentyp (LIKE).
+- **Aktive Filter:** Chip-Zeile über Ergebnissen + „Alle zurücksetzen"-Link in der Sidebar.
+- **Filter-Persistenz:** Sort- und Pagination-Links behalten alle aktiven Filter bei.
+
+### 🛠 Tech
+- **Repository:** `findPaginated()` auf `array $filters` umgestellt (skalierbar, 8 Filter-Keys).
+- **Controller:** 8 Query-Parameter ausgelesen und als `$filters`-Array weitergereicht.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,15 @@ Autowiring and autoconfiguration are enabled by default in `config/services.yaml
 - `?sort=newest` – sorted by `createdAt` DESC
 - `?page=N` – page number (6 items per page, uses Doctrine `Paginator`)
 - `?verified=1` – filter to verified restaurants only
+- `?wheelchair=1` – filter to wheelchair-accessible restaurants
+- `?toilet=1` – filter to restaurants with accessible toilet
+- `?dogs=1` – filter to restaurants that allow assistance dogs
+- `?lighting=1` – filter to restaurants with bright lighting
+- `?open=1` – filter to currently open restaurants
+- `?city=Strassen` – filter by city name (LIKE search)
+- `?cuisine=Italienisch` – filter by cuisine type (LIKE search)
+
+All filter params are combinable. `RestaurantRepository::findPaginated(string $sort, int $page, int $limit, array $filters)` handles all filtering.
 
 ### Data Fixtures
 - Restaurant fixtures: 11 Luxembourg restaurants (`RestaurantFixtures`); each restaurant has accessibility fields (`isWheelchairAccessible`, `hasAccessibleToilet`, `allowsAssistanceDogs`, `hasBrightLighting`), payment method fields (`acceptsCash`, `acceptsCard`, `acceptsPayconiq`), and verification fields (`isVerified`, `verifiedAt`, `verifiedBy`). 3 restaurants are verified: Pizzeria Bella Vista, Sushi Zen, Green Bowl.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An open platform to find and rate accessible restaurants in Luxembourg. Built fo
 ## 🚀 Project Status
 
 **The first beta version is live.**
-The homepage has been redesigned as a landing page with a hero section, "How it works" steps, restaurant preview, and call-to-action areas. A dedicated restaurant listing at `/restaurants` with pagination and sorting is available. An admin panel at `/admin` allows ROLE_ADMIN users to fully manage (CRUD) restaurants. Transactional emails are powered by Brevo (formerly Sendinblue) with Mailpit for local development. Next up: map view and active filtering.
+The homepage has been redesigned as a landing page with a hero section, "How it works" steps, restaurant preview, and call-to-action areas. A dedicated restaurant listing at `/restaurants` with pagination, sorting, and full filter support (accessibility, open status, city, cuisine) is available. An admin panel at `/admin` allows ROLE_ADMIN users to fully manage (CRUD) restaurants. Transactional emails are powered by Brevo (formerly Sendinblue) with Mailpit for local development. Next up: map view.
 
 ## 🎯 Features & Progress
 
@@ -39,7 +39,7 @@ Current development status of the platform.
 - [x] **Accessibility Icons:** Display of criteria (wheelchair, toilet, assistance dog, lighting).
 - [x] **Detail Page:** Individual view with address and additional information.
 - [x] **Payment Methods:** Display of accepted payment methods (cash, card, Payconiq) per restaurant.
-- [ ] **Filters:** Filter by criteria (e.g., "Step-free entrance").
+- [x] **Filters:** Filter by accessibility criteria (wheelchair, toilet, dogs, lighting), open status, city, and cuisine type.
 
 ### 👤 User & Community
 - [ ] **User Profiles:** Save favorites.

--- a/src/Controller/RestaurantController.php
+++ b/src/Controller/RestaurantController.php
@@ -22,9 +22,19 @@ final class RestaurantController extends AbstractController
         }
 
         $page = max(1, $request->query->getInt('page', 1));
-        $verifiedOnly = $request->query->getBoolean('verified', false);
 
-        $paginator = $restaurantRepository->findPaginated($sort, $page, self::LIMIT, $verifiedOnly);
+        $filters = [
+            'verified'   => $request->query->getBoolean('verified', false),
+            'wheelchair' => $request->query->getBoolean('wheelchair', false),
+            'toilet'     => $request->query->getBoolean('toilet', false),
+            'dogs'       => $request->query->getBoolean('dogs', false),
+            'lighting'   => $request->query->getBoolean('lighting', false),
+            'open'       => $request->query->getBoolean('open', false),
+            'city'       => trim($request->query->getString('city', '')),
+            'cuisine'    => trim($request->query->getString('cuisine', '')),
+        ];
+
+        $paginator = $restaurantRepository->findPaginated($sort, $page, self::LIMIT, $filters);
         $total = count($paginator);
         $lastPage = max(1, (int) ceil($total / self::LIMIT));
 
@@ -34,7 +44,7 @@ final class RestaurantController extends AbstractController
             'lastPage' => $lastPage,
             'total' => $total,
             'sort' => $sort,
-            'verifiedOnly' => $verifiedOnly,
+            'filters' => $filters,
         ]);
     }
 

--- a/src/Repository/RestaurantRepository.php
+++ b/src/Repository/RestaurantRepository.php
@@ -30,12 +30,33 @@ class RestaurantRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findPaginated(string $sort = 'rating', int $page = 1, int $limit = 6, bool $verifiedOnly = false): Paginator
+    public function findPaginated(string $sort = 'rating', int $page = 1, int $limit = 6, array $filters = []): Paginator
     {
         $qb = $this->createQueryBuilder('r');
 
-        if ($verifiedOnly) {
-            $qb->andWhere('r.isVerified = :verified')->setParameter('verified', true);
+        if (!empty($filters['verified'])) {
+            $qb->andWhere('r.isVerified = true');
+        }
+        if (!empty($filters['wheelchair'])) {
+            $qb->andWhere('r.isWheelchairAccessible = true');
+        }
+        if (!empty($filters['toilet'])) {
+            $qb->andWhere('r.hasAccessibleToilet = true');
+        }
+        if (!empty($filters['dogs'])) {
+            $qb->andWhere('r.allowsAssistanceDogs = true');
+        }
+        if (!empty($filters['lighting'])) {
+            $qb->andWhere('r.hasBrightLighting = true');
+        }
+        if (!empty($filters['open'])) {
+            $qb->andWhere('r.isOpen = true');
+        }
+        if (!empty($filters['city'])) {
+            $qb->andWhere('r.city LIKE :city')->setParameter('city', '%'.$filters['city'].'%');
+        }
+        if (!empty($filters['cuisine'])) {
+            $qb->andWhere('r.cuisine LIKE :cuisine')->setParameter('cuisine', '%'.$filters['cuisine'].'%');
         }
 
         match ($sort) {

--- a/templates/restaurant/index.html.twig
+++ b/templates/restaurant/index.html.twig
@@ -25,18 +25,31 @@
                             <h3 class="font-bold text-lg">Filter</h3>
                         </div>
 
-                        <form>
+                        <form method="get" action="{{ path('app_restaurant_index') }}">
+                            <input type="hidden" name="sort" value="{{ sort }}">
+
                             <div class="mb-6">
-                                <label class="block text-sm font-semibold text-gray-700 mb-2">Ort</label>
-                                <input type="text" placeholder="Stadt oder PLZ..." class="w-full bg-gray-50 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none">
+                                <label class="block text-sm font-semibold text-gray-700 mb-2" for="filter-city">Ort</label>
+                                <input type="text" id="filter-city" name="city" value="{{ filters.city }}" placeholder="Stadt..." class="w-full bg-gray-50 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none">
                             </div>
 
                             <div class="mb-6">
-                                <label class="block text-sm font-semibold text-gray-700 mb-3">Qualität</label>
+                                <label class="block text-sm font-semibold text-gray-700 mb-2" for="filter-cuisine">Küche</label>
+                                <input type="text" id="filter-cuisine" name="cuisine" value="{{ filters.cuisine }}" placeholder="z.B. Italienisch" class="w-full bg-gray-50 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none">
+                            </div>
+
+                            <div class="mb-6">
+                                <label class="block text-sm font-semibold text-gray-700 mb-3">Status</label>
+                                <label class="flex items-center gap-3 mb-2 cursor-pointer group">
+                                    <input type="checkbox" name="open" value="1"
+                                           class="rounded text-green-600 focus:ring-green-500 border-gray-300"
+                                           {{ filters.open ? 'checked' : '' }}>
+                                    <span class="text-sm text-gray-600 group-hover:text-green-700">🟢 Nur geöffnete Lokale</span>
+                                </label>
                                 <label class="flex items-center gap-3 cursor-pointer group">
                                     <input type="checkbox" name="verified" value="1"
                                            class="rounded text-cyan-600 focus:ring-cyan-500 border-gray-300"
-                                           {{ verifiedOnly ? 'checked' : '' }}>
+                                           {{ filters.verified ? 'checked' : '' }}>
                                     <span class="text-sm text-gray-600 group-hover:text-cyan-700">✓ Nur verifizierte Lokale</span>
                                 </label>
                             </div>
@@ -45,29 +58,44 @@
                                 <label class="block text-sm font-semibold text-gray-700 mb-3">Bedürfnisse</label>
 
                                 <label class="flex items-center gap-3 mb-2 cursor-pointer group">
-                                    <input type="checkbox" class="rounded text-purple-600 focus:ring-purple-500 border-gray-300">
+                                    <input type="checkbox" name="wheelchair" value="1"
+                                           class="rounded text-purple-600 focus:ring-purple-500 border-gray-300"
+                                           {{ filters.wheelchair ? 'checked' : '' }}>
                                     <span class="text-sm text-gray-600 group-hover:text-purple-700">♿ Rollstuhl (stufenlos)</span>
                                 </label>
 
                                 <label class="flex items-center gap-3 mb-2 cursor-pointer group">
-                                    <input type="checkbox" class="rounded text-purple-600 focus:ring-purple-500 border-gray-300">
+                                    <input type="checkbox" name="toilet" value="1"
+                                           class="rounded text-purple-600 focus:ring-purple-500 border-gray-300"
+                                           {{ filters.toilet ? 'checked' : '' }}>
                                     <span class="text-sm text-gray-600 group-hover:text-purple-700">🚻 Barrierefreies WC</span>
                                 </label>
 
                                 <label class="flex items-center gap-3 mb-2 cursor-pointer group">
-                                    <input type="checkbox" class="rounded text-purple-600 focus:ring-purple-500 border-gray-300">
+                                    <input type="checkbox" name="dogs" value="1"
+                                           class="rounded text-purple-600 focus:ring-purple-500 border-gray-300"
+                                           {{ filters.dogs ? 'checked' : '' }}>
                                     <span class="text-sm text-gray-600 group-hover:text-purple-700">🐕 Assistenzhund erlaubt</span>
                                 </label>
 
                                 <label class="flex items-center gap-3 cursor-pointer group">
-                                    <input type="checkbox" class="rounded text-purple-600 focus:ring-purple-500 border-gray-300">
+                                    <input type="checkbox" name="lighting" value="1"
+                                           class="rounded text-purple-600 focus:ring-purple-500 border-gray-300"
+                                           {{ filters.lighting ? 'checked' : '' }}>
                                     <span class="text-sm text-gray-600 group-hover:text-purple-700">💡 Helle Beleuchtung</span>
                                 </label>
                             </div>
 
-                            <button class="w-full bg-gray-900 hover:bg-black text-white font-medium py-2 rounded-lg transition">
+                            <button type="submit" class="w-full bg-gray-900 hover:bg-black text-white font-medium py-2 rounded-lg transition">
                                 Filter anwenden
                             </button>
+
+                            {% set activeCount = (filters.verified ? 1 : 0) + (filters.wheelchair ? 1 : 0) + (filters.toilet ? 1 : 0) + (filters.dogs ? 1 : 0) + (filters.lighting ? 1 : 0) + (filters.open ? 1 : 0) + (filters.city ? 1 : 0) + (filters.cuisine ? 1 : 0) %}
+                            {% if activeCount > 0 %}
+                                <a href="{{ path('app_restaurant_index', {sort: sort}) }}" class="block text-center text-xs text-red-500 hover:text-red-700 mt-3 transition">
+                                    × Alle Filter zurücksetzen ({{ activeCount }})
+                                </a>
+                            {% endif %}
                         </form>
                     </div>
                 </aside>
@@ -76,23 +104,47 @@
                 <main class="w-full lg:w-3/4">
 
                     {# Sortierung & Ergebnisanzahl #}
-                    <div class="flex justify-between items-center mb-6">
+                    {% set filterParams = {
+                        verified:   filters.verified   ? 1 : null,
+                        wheelchair: filters.wheelchair ? 1 : null,
+                        toilet:     filters.toilet     ? 1 : null,
+                        dogs:       filters.dogs       ? 1 : null,
+                        lighting:   filters.lighting   ? 1 : null,
+                        open:       filters.open       ? 1 : null,
+                        city:       filters.city ?: null,
+                        cuisine:    filters.cuisine ?: null
+                    } %}
+                    <div class="flex justify-between items-center mb-4">
                         <h2 class="text-xl font-bold text-gray-800">{{ total }} Ergebnisse gefunden</h2>
                         <div class="flex items-center gap-2">
-                            <a href="{{ path('app_restaurant_index', {sort: 'rating', page: 1, verified: verifiedOnly ? 1 : null}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'rating', page: 1}|merge(filterParams)) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'rating' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 Beste Bewertung
                             </a>
-                            <a href="{{ path('app_restaurant_index', {sort: 'name', page: 1, verified: verifiedOnly ? 1 : null}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'name', page: 1}|merge(filterParams)) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'name' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 A – Z
                             </a>
-                            <a href="{{ path('app_restaurant_index', {sort: 'newest', page: 1, verified: verifiedOnly ? 1 : null}) }}"
+                            <a href="{{ path('app_restaurant_index', {sort: 'newest', page: 1}|merge(filterParams)) }}"
                                class="px-3 py-1.5 text-sm rounded-lg border transition {{ sort == 'newest' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                 Neueste
                             </a>
                         </div>
                     </div>
+
+                    {# Aktive Filter als Chips #}
+                    {% if activeCount > 0 %}
+                    <div class="flex flex-wrap gap-2 mb-4">
+                        {% if filters.open %}<span class="inline-flex items-center text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full border border-green-200">🟢 Geöffnet</span>{% endif %}
+                        {% if filters.verified %}<span class="inline-flex items-center text-xs bg-cyan-100 text-cyan-700 px-2 py-1 rounded-full border border-cyan-200">✓ Verifiziert</span>{% endif %}
+                        {% if filters.wheelchair %}<span class="inline-flex items-center text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full border border-purple-200">♿ Rollstuhlgerecht</span>{% endif %}
+                        {% if filters.toilet %}<span class="inline-flex items-center text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full border border-purple-200">🚻 Barrierefreies WC</span>{% endif %}
+                        {% if filters.dogs %}<span class="inline-flex items-center text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full border border-purple-200">🐕 Assistenzhund</span>{% endif %}
+                        {% if filters.lighting %}<span class="inline-flex items-center text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full border border-purple-200">💡 Helle Beleuchtung</span>{% endif %}
+                        {% if filters.city %}<span class="inline-flex items-center text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full border border-gray-200">📍 {{ filters.city }}</span>{% endif %}
+                        {% if filters.cuisine %}<span class="inline-flex items-center text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full border border-gray-200">🍽️ {{ filters.cuisine }}</span>{% endif %}
+                    </div>
+                    {% endif %}
 
                     {# Restaurant-Karten #}
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -173,21 +225,21 @@
                     {% if lastPage > 1 %}
                         <nav class="flex justify-center items-center gap-2 mt-10" aria-label="Seitennavigation">
                             {% if currentPage > 1 %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage - 1, verified: verifiedOnly ? 1 : null}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage - 1}|merge(filterParams)) }}"
                                    class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 hover:border-purple-400 transition text-sm">
                                     ← Zurück
                                 </a>
                             {% endif %}
 
                             {% for p in 1..lastPage %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: p, verified: verifiedOnly ? 1 : null}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: p}|merge(filterParams)) }}"
                                    class="px-4 py-2 rounded-lg border text-sm transition {{ p == currentPage ? 'bg-purple-600 text-white border-purple-600 font-bold' : 'bg-white text-gray-700 border-gray-300 hover:border-purple-400' }}">
                                     {{ p }}
                                 </a>
                             {% endfor %}
 
                             {% if currentPage < lastPage %}
-                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage + 1, verified: verifiedOnly ? 1 : null}) }}"
+                                <a href="{{ path('app_restaurant_index', {sort: sort, page: currentPage + 1}|merge(filterParams)) }}"
                                    class="px-4 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 hover:border-purple-400 transition text-sm">
                                     Weiter →
                                 </a>


### PR DESCRIPTION
## Summary

- Barrierefreiheits-Checkboxen (♿ Rollstuhl, 🚻 WC, 🐕 Assistenzhund, 💡 Beleuchtung) ans Backend angeschlossen
- Status-Filter: „Nur geöffnete Lokale" + „Nur verifizierte Lokale"
- Freitext-Filter für Ort (city) und Küche (cuisine) per LIKE-Suche
- Aktive Filter als Chips über dem Grid + „× Alle zurücksetzen"-Link
- Sort- und Pagination-Links behalten alle aktiven Filter bei

## Test plan

- [ ] `/restaurants?wheelchair=1` → nur rollstuhlgerechte Lokale
- [ ] `/restaurants?wheelchair=1&toilet=1` → kombinierte Filter
- [ ] `/restaurants?city=Strassen` → findet Sushi Zen
- [ ] `/restaurants?open=1&sort=name` → geöffnet + alphabetisch
- [ ] `/restaurants?verified=1&wheelchair=1` → verifiziert UND rollstuhlgerecht
- [ ] Pagination bleibt bei aktiven Filtern erhalten
- [ ] „Alle zurücksetzen" leert alle Filter

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)