### PR TITLE
Add ordering options per restaurant (closes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ---
 
+## [2026.03.14d] – Bestelloptionen (Issue #43)
+
+### 🚀 Features
+- **Bestelloptionen pro Restaurant:** Anzeige über welche Plattformen bestellt werden kann (Uber Eats, Deliveroo, Just Eat, Telefon, Webseite, Andere).
+- **Detailseite:** Neue Sektion „Online bestellen" mit klickbaren CTA-Buttons und Direktlinks.
+- **Admin-Formular:** Dynamische Collection zum Hinzufügen/Entfernen von Bestelloptionen.
+- **Admin-Liste:** Neue Spalte „Bestellung" mit Plattform-Emoji-Icons.
+
+### 🛠 Tech
+- **Enum:** `App\Enum\OrderingPlatform` – PHP Backed Enum mit 6 Werten, Helper-Methoden `label()`, `emoji()`, `actionLabel()`.
+- **Entity:** `OrderingOption` (ManyToOne → Restaurant, CASCADE DELETE) mit `platform` (VARCHAR 20) und `url` (VARCHAR 500).
+- **Form:** `OrderingOptionType` als CollectionType-Entry in `RestaurantType` (`by_reference: false`).
+- **Migration:** `Version20260314200000` – `ordering_option`-Tabelle.
+- **Fixtures:** 4 Restaurants mit Bestelloptionen (Pizzeria Bella Vista, Sushi Zen, Green Bowl, Burger & Co.).
+
+---
+
 ## [2026.03.14c] – Ernährungsoptionen (Issue #45)
 
 ### 🚀 Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ The UI language is German/Luxembourgish. The codebase comments (Makefile, templa
 src/
 ├── Controller/          # Route controllers (attribute-based routing)
 ├── DataFixtures/        # Doctrine fixtures (restaurant data + user test data)
-├── Entity/              # Doctrine entities (User, Restaurant)
-├── Enum/                # PHP Backed Enums (Language)
+├── Entity/              # Doctrine entities (User, Restaurant, RestaurantImage, OrderingOption)
+├── Enum/                # PHP Backed Enums (Language, OrderingPlatform)
 ├── Repository/          # Doctrine repositories (UserRepository, RestaurantRepository)
 └── Kernel.php           # Symfony kernel
 
@@ -179,8 +179,15 @@ Felder: id, filename (VARCHAR 255), altText (VARCHAR 255 nullable), restaurant (
 Collection auf Restaurant: `$images` (OneToMany, cascade persist+remove, orphanRemoval, OrderBy uploadedAt ASC).
 Service: `ImageUploadService` – Upload nach `public/uploads/restaurants/`, Löschung inkl. Dateisystem.
 
+## Entity: OrderingOption (Issue #43)
+Felder: id (int, PK), platform (VARCHAR 20 – Werte aus `App\Enum\OrderingPlatform`), url (VARCHAR 500), restaurant (ManyToOne Restaurant, CASCADE DELETE).
+Collection auf Restaurant: `$orderingOptions` (OneToMany, cascade persist+remove, orphanRemoval).
+Enum: `App\Enum\OrderingPlatform` – Cases: `uber_eats`, `deliveroo`, `just_eat`, `phone`, `website`, `other`. Helper: `label()`, `emoji()`, `actionLabel()`.
+Form: `OrderingOptionType` als CollectionType-Entry in `RestaurantType` (`by_reference: false`).
+Migration: `Version20260314200000`.
+
 ### Data Fixtures
-- Restaurant fixtures: 11 Luxembourg restaurants (`RestaurantFixtures`); each restaurant has accessibility fields (`isWheelchairAccessible`, `hasAccessibleToilet`, `allowsAssistanceDogs`, `hasBrightLighting`), payment method fields (`acceptsCash`, `acceptsCard`, `acceptsPayconiq`), dietary fields (`isVegan`, `isVegetarian`, `isHalal`), and verification fields (`isVerified`, `verifiedAt`, `verifiedBy`). 3 restaurants are verified: Pizzeria Bella Vista, Sushi Zen, Green Bowl.
+- Restaurant fixtures: 11 Luxembourg restaurants (`RestaurantFixtures`); each restaurant has accessibility fields (`isWheelchairAccessible`, `hasAccessibleToilet`, `allowsAssistanceDogs`, `hasBrightLighting`), payment method fields (`acceptsCash`, `acceptsCard`, `acceptsPayconiq`), dietary fields (`isVegan`, `isVegetarian`, `isHalal`), verification fields (`isVerified`, `verifiedAt`, `verifiedBy`), and ordering options. 3 restaurants are verified: Pizzeria Bella Vista, Sushi Zen, Green Bowl. 4 restaurants have ordering options: Pizzeria Bella Vista, Sushi Zen, Green Bowl, Burger & Co.
 - User fixtures: 3 test users (`UserFixtures`) with hashed passwords via Symfony PasswordHasher
   - `admin@endlech.lu` / `admin123` — ROLE_ADMIN, verified
   - `user@endlech.lu` / `user123` — ROLE_USER, verified

--- a/migrations/Version20260314200000.php
+++ b/migrations/Version20260314200000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260314200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create ordering_option table for restaurant ordering platforms';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE ordering_option (
+            id INT AUTO_INCREMENT NOT NULL,
+            restaurant_id INT NOT NULL,
+            platform VARCHAR(20) NOT NULL,
+            url VARCHAR(500) NOT NULL,
+            INDEX IDX_ordering_option_restaurant (restaurant_id),
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE ordering_option ADD CONSTRAINT FK_ordering_option_restaurant
+            FOREIGN KEY (restaurant_id) REFERENCES restaurant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ordering_option DROP FOREIGN KEY FK_ordering_option_restaurant');
+        $this->addSql('DROP TABLE ordering_option');
+    }
+}

--- a/src/DataFixtures/RestaurantFixtures.php
+++ b/src/DataFixtures/RestaurantFixtures.php
@@ -2,9 +2,11 @@
 
 namespace App\DataFixtures;
 
+use App\Entity\OrderingOption;
 use App\Entity\Restaurant;
 use App\Entity\User;
 use App\Enum\Language;
+use App\Enum\OrderingPlatform;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -39,6 +41,11 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'accessibilityNotes'     => ['ok:Eingang stufenlos', 'ok:WC Tür > 90cm'],
                 'isVerified'             => true,
                 'spokenLanguages'        => [Language::LU, Language::DE, Language::FR, Language::EN, Language::OTHER],
+                'orderingOptions'        => [
+                    [OrderingPlatform::UBER_EATS, 'https://www.ubereats.com/lu/store/pizzeria-bella-vista'],
+                    [OrderingPlatform::WEBSITE, 'https://www.bellavista.lu'],
+                    [OrderingPlatform::PHONE, '+352 26 12 34 56'],
+                ],
             ],
             [
                 'name'                   => 'Umami Corner',
@@ -79,6 +86,10 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'isHalal'                => true,
                 'accessibilityNotes'     => ['ok:Parkplatz vor der Tür'],
                 'spokenLanguages'        => [Language::LU, Language::DE, Language::FR],
+                'orderingOptions'        => [
+                    [OrderingPlatform::JUST_EAT, 'https://www.just-eat.lu/menu/burger-and-co'],
+                    [OrderingPlatform::PHONE, '+352 27 98 76 54'],
+                ],
             ],
             [
                 'name'                   => 'Le Jardin Brasserie',
@@ -160,6 +171,10 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'accessibilityNotes'     => ['ok:Vollständig barrierefrei', 'ok:Rollstuhlrampe vorhanden', 'ok:Barrierefreies WC'],
                 'isVerified'             => true,
                 'spokenLanguages'        => [Language::LU, Language::DE, Language::FR, Language::EN],
+                'orderingOptions'        => [
+                    [OrderingPlatform::DELIVEROO, 'https://deliveroo.lu/menu/luxembourg/sushi-zen'],
+                    [OrderingPlatform::JUST_EAT, 'https://www.just-eat.lu/menu/sushi-zen'],
+                ],
             ],
             [
                 'name'                   => 'Wäinhaus am Markt',
@@ -221,6 +236,10 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'accessibilityNotes'     => ['ok:Vollständig barrierefrei', 'ok:Induktive Höranlage vorhanden'],
                 'isVerified'             => true,
                 'spokenLanguages'        => [Language::LU, Language::DE, Language::FR, Language::EN, Language::PT],
+                'orderingOptions'        => [
+                    [OrderingPlatform::UBER_EATS, 'https://www.ubereats.com/lu/store/green-bowl'],
+                    [OrderingPlatform::WEBSITE, 'https://www.greenbowl.lu/order'],
+                ],
             ],
             [
                 'name'                   => 'Brasserie du Grund',
@@ -270,6 +289,13 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
             if ($isVerified) {
                 $restaurant->setVerifiedAt(new \DateTimeImmutable('2026-01-15'));
                 $restaurant->setVerifiedBy($this->getReference(UserFixtures::REFERENCE_ADMIN, User::class));
+            }
+
+            foreach ($data['orderingOptions'] ?? [] as [$platform, $url]) {
+                $option = new OrderingOption();
+                $option->setPlatform($platform);
+                $option->setUrl($url);
+                $restaurant->addOrderingOption($option);
             }
 
             $manager->persist($restaurant);

--- a/src/Entity/OrderingOption.php
+++ b/src/Entity/OrderingOption.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\OrderingPlatform;
+use App\Repository\OrderingOptionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: OrderingOptionRepository::class)]
+class OrderingOption
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 20)]
+    private string $platform = '';
+
+    #[ORM\Column(length: 500)]
+    private string $url = '';
+
+    #[ORM\ManyToOne(inversedBy: 'orderingOptions')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Restaurant $restaurant = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPlatform(): string
+    {
+        return $this->platform;
+    }
+
+    public function getPlatformEnum(): ?OrderingPlatform
+    {
+        return OrderingPlatform::tryFrom($this->platform);
+    }
+
+    public function setPlatform(OrderingPlatform|string $platform): static
+    {
+        $this->platform = $platform instanceof OrderingPlatform ? $platform->value : $platform;
+
+        return $this;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getRestaurant(): ?Restaurant
+    {
+        return $this->restaurant;
+    }
+
+    public function setRestaurant(?Restaurant $restaurant): static
+    {
+        $this->restaurant = $restaurant;
+
+        return $this;
+    }
+}

--- a/src/Entity/Restaurant.php
+++ b/src/Entity/Restaurant.php
@@ -89,10 +89,15 @@ class Restaurant
     #[ORM\OrderBy(['uploadedAt' => 'ASC'])]
     private Collection $images;
 
+    /** @var Collection<int, OrderingOption> */
+    #[ORM\OneToMany(mappedBy: 'restaurant', targetEntity: OrderingOption::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $orderingOptions;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->images = new ArrayCollection();
+        $this->orderingOptions = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -373,5 +378,32 @@ class Restaurant
     public function getImages(): Collection
     {
         return $this->images;
+    }
+
+    /** @return Collection<int, OrderingOption> */
+    public function getOrderingOptions(): Collection
+    {
+        return $this->orderingOptions;
+    }
+
+    public function addOrderingOption(OrderingOption $option): static
+    {
+        if (!$this->orderingOptions->contains($option)) {
+            $this->orderingOptions->add($option);
+            $option->setRestaurant($this);
+        }
+
+        return $this;
+    }
+
+    public function removeOrderingOption(OrderingOption $option): static
+    {
+        if ($this->orderingOptions->removeElement($option)) {
+            if ($option->getRestaurant() === $this) {
+                $option->setRestaurant(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/src/Enum/OrderingPlatform.php
+++ b/src/Enum/OrderingPlatform.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Enum;
+
+enum OrderingPlatform: string
+{
+    case UBER_EATS = 'uber_eats';
+    case DELIVEROO = 'deliveroo';
+    case JUST_EAT = 'just_eat';
+    case PHONE = 'phone';
+    case WEBSITE = 'website';
+    case OTHER = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::UBER_EATS => 'Uber Eats',
+            self::DELIVEROO => 'Deliveroo',
+            self::JUST_EAT => 'Just Eat',
+            self::PHONE => 'Telefon',
+            self::WEBSITE => 'Webseite',
+            self::OTHER => 'Andere',
+        };
+    }
+
+    public function emoji(): string
+    {
+        return match ($this) {
+            self::UBER_EATS => '🚗',
+            self::DELIVEROO => '🦘',
+            self::JUST_EAT => '🍽️',
+            self::PHONE => '📞',
+            self::WEBSITE => '🌐',
+            self::OTHER => '📦',
+        };
+    }
+
+    public function actionLabel(): string
+    {
+        return match ($this) {
+            self::PHONE => 'Anrufen',
+            self::WEBSITE => 'Zur Webseite',
+            default => 'Bestellen',
+        };
+    }
+}

--- a/src/Form/OrderingOptionType.php
+++ b/src/Form/OrderingOptionType.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\OrderingOption;
+use App\Enum\OrderingPlatform;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class OrderingOptionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('platform', ChoiceType::class, [
+                'label' => 'Plattform',
+                'choices' => OrderingPlatform::cases(),
+                'choice_value' => fn (?OrderingPlatform $p) => $p?->value,
+                'choice_label' => fn (OrderingPlatform $p) => $p->emoji().' '.$p->label(),
+                'placeholder' => 'Plattform wählen...',
+                'constraints' => [
+                    new NotBlank(message: 'Bitte wähle eine Plattform.'),
+                ],
+            ])
+            ->add('url', TextType::class, [
+                'label' => 'URL / Telefonnummer',
+                'attr' => ['placeholder' => 'https://... oder +352...'],
+                'constraints' => [
+                    new NotBlank(message: 'Bitte gib eine URL oder Telefonnummer ein.'),
+                    new Length(max: 500, maxMessage: 'Die URL darf maximal {{ limit }} Zeichen lang sein.'),
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => OrderingOption::class,
+        ]);
+    }
+}

--- a/src/Form/RestaurantType.php
+++ b/src/Form/RestaurantType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Valid;
 
 class RestaurantType extends AbstractType
 {
@@ -123,6 +124,18 @@ class RestaurantType extends AbstractType
                 'multiple' => true,
                 'expanded' => true,
                 'required' => false,
+            ])
+            ->add('orderingOptions', CollectionType::class, [
+                'label' => 'Bestelloptionen',
+                'entry_type' => OrderingOptionType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'prototype' => true,
+                'by_reference' => false,
+                'required' => false,
+                'constraints' => [
+                    new Valid(),
+                ],
             ])
             ->add('accessibilityNotes', CollectionType::class, [
                 'label' => 'Hinweise zur Barrierefreiheit',

--- a/src/Repository/OrderingOptionRepository.php
+++ b/src/Repository/OrderingOptionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\OrderingOption;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<OrderingOption>
+ */
+class OrderingOptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OrderingOption::class);
+    }
+}

--- a/templates/admin/restaurant/_form.html.twig
+++ b/templates/admin/restaurant/_form.html.twig
@@ -125,6 +125,38 @@
         {% endfor %}
     </fieldset>
 
+    {# --- Bestelloptionen (dynamische Collection) --- #}
+    <fieldset>
+        <legend class="text-lg font-bold text-gray-700 border-b border-gray-200 pb-2 mb-4">Bestelloptionen</legend>
+        <p class="text-xs text-gray-400 mb-3">Plattformen, über die Kunden bestellen können (Uber Eats, Deliveroo, Telefon, etc.)</p>
+
+        <div data-controller="collection-form"
+             data-collection-form-prototype-value="{{ form_widget(form.orderingOptions.vars.prototype)|e('html_attr') }}">
+
+            <div data-collection-form-target="entries" class="space-y-3">
+                {% for option in form.orderingOptions %}
+                    <div class="flex items-center gap-2" data-collection-form-target="entry">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-2 flex-1">
+                            {{ form_widget(option.platform, {'attr': {'class': 'w-full bg-gray-50 border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500 focus:outline-none transition'}}) }}
+                            {{ form_widget(option.url, {'attr': {'class': 'w-full bg-gray-50 border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500 focus:outline-none transition'}}) }}
+                        </div>
+                        <button type="button" data-action="collection-form#removeEntry"
+                                class="text-red-500 hover:text-red-700 text-sm font-bold px-2 py-1 shrink-0 transition">
+                            ✕
+                        </button>
+                    </div>
+                    {{ form_errors(option.platform, {'attr': {'class': 'text-red-600 text-xs mt-1'}}) }}
+                    {{ form_errors(option.url, {'attr': {'class': 'text-red-600 text-xs mt-1'}}) }}
+                {% endfor %}
+            </div>
+
+            <button type="button" data-action="collection-form#addEntry"
+                    class="mt-3 text-sm font-semibold text-purple-600 hover:text-purple-800 transition">
+                + Bestellmöglichkeit hinzufügen
+            </button>
+        </div>
+    </fieldset>
+
     {# --- Hinweise zur Barrierefreiheit (dynamische Collection) --- #}
     <fieldset>
         <legend class="text-lg font-bold text-gray-700 border-b border-gray-200 pb-2 mb-4">Hinweise zur Barrierefreiheit</legend>

--- a/templates/admin/restaurant/index.html.twig
+++ b/templates/admin/restaurant/index.html.twig
@@ -24,6 +24,7 @@
                     <th class="px-4 py-3 font-semibold text-gray-600">Status</th>
                     <th class="px-4 py-3 font-semibold text-gray-600">Barrierefreiheit</th>
                     <th class="px-4 py-3 font-semibold text-gray-600">Ernährung</th>
+                    <th class="px-4 py-3 font-semibold text-gray-600">Bestellung</th>
                     <th class="px-4 py-3 font-semibold text-gray-600">Verifiziert</th>
                     <th class="px-4 py-3 font-semibold text-gray-600 text-right">Aktionen</th>
                 </tr>
@@ -67,6 +68,20 @@
                         </div>
                     </td>
                     <td class="px-4 py-3">
+                        {% if restaurant.orderingOptions|length > 0 %}
+                            <div class="flex gap-1">
+                                {% for option in restaurant.orderingOptions %}
+                                    {% set platform = option.platformEnum %}
+                                    {% if platform %}
+                                        <span title="{{ platform.label }}">{{ platform.emoji }}</span>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% else %}
+                            <span class="text-gray-400">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-3">
                         <form method="post" action="{{ path('admin_restaurant_toggle_verified', {id: restaurant.id}) }}">
                             <input type="hidden" name="_token" value="{{ csrf_token('toggle-verified-' ~ restaurant.id) }}">
                             <button type="submit"
@@ -96,7 +111,7 @@
                 </tr>
                 {% else %}
                 <tr>
-                    <td colspan="10" class="px-4 py-8 text-center text-gray-400">
+                    <td colspan="11" class="px-4 py-8 text-center text-gray-400">
                         Noch keine Restaurants vorhanden.
                     </td>
                 </tr>

--- a/templates/restaurant/show.html.twig
+++ b/templates/restaurant/show.html.twig
@@ -172,6 +172,33 @@
                 </div>
             </div>
 
+            {# --- BESTELLOPTIONEN --- #}
+            {% if restaurant.orderingOptions is not empty %}
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+                    <h2 class="text-lg font-bold text-gray-800 mb-4">Online bestellen</h2>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {% for option in restaurant.orderingOptions %}
+                            {% set platform = option.platformEnum %}
+                            {% if platform %}
+                                <a href="{{ platform.value == 'phone' ? 'tel:' ~ option.url : option.url }}"
+                                   target="{{ platform.value == 'phone' ? '_self' : '_blank' }}"
+                                   rel="{{ platform.value == 'phone' ? '' : 'noopener noreferrer' }}"
+                                   class="flex items-center gap-3 p-4 rounded-lg bg-purple-50 border border-purple-100 hover:bg-purple-100 hover:border-purple-200 transition group">
+                                    <span class="text-2xl">{{ platform.emoji }}</span>
+                                    <div class="flex-1 min-w-0">
+                                        <p class="text-sm font-semibold text-purple-700 group-hover:text-purple-800">{{ platform.label }}</p>
+                                        <p class="text-xs text-purple-500 truncate">{{ option.url }}</p>
+                                    </div>
+                                    <span class="text-xs font-bold text-purple-600 bg-purple-100 px-3 py-1 rounded-full group-hover:bg-purple-200 shrink-0">
+                                        {{ platform.actionLabel }} →
+                                    </span>
+                                </a>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+
             {# --- GESPROCHENE SPRACHEN --- #}
             {% if restaurant.spokenLanguages is not empty %}
                 <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">


### PR DESCRIPTION
## Summary
- **OrderingPlatform Enum** mit 6 Plattformen (Uber Eats, Deliveroo, Just Eat, Telefon, Webseite, Andere) inkl. `label()`, `emoji()`, `actionLabel()`
- **OrderingOption Entity** (ManyToOne → Restaurant, CASCADE DELETE) mit dynamischer Collection im Admin-Formular
- **Detailseite:** Neue Sektion „Online bestellen" mit klickbaren CTA-Buttons und Direktlinks (`tel:` für Telefon, `target="_blank"` für URLs)
- **Admin-Formular:** Dynamische Collection zum Hinzufügen/Entfernen von Bestelloptionen (wiederverwendet `collection-form` Stimulus-Controller)
- **Admin-Liste:** Neue Spalte „Bestellung" mit Plattform-Emoji-Icons
- **Fixtures:** 4 Restaurants mit Bestelloptionen (Pizzeria Bella Vista, Sushi Zen, Green Bowl, Burger & Co.)

## Test plan
- [x] `php bin/console doctrine:migrations:migrate` – Migration ausführen
- [x] `make fixtures` – Fixtures laden, prüfen ob OrderingOptions erstellt werden
- [x] Admin-Panel: Restaurant bearbeiten → Bestelloptionen hinzufügen/entfernen → Speichern
- [x] Detailseite: Sektion „Online bestellen" mit klickbaren Links prüfen
- [x] Detailseite: Bei Restaurant ohne Optionen → Sektion ausgeblendet
- [x] Admin-Liste: Neue Spalte „Bestellung" mit Emoji-Icons sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)