### PR TITLE
Add submitted restaurants to user profile (closes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 ## [Unreleased]
 
 ### Added
+- **Profil: Eingereichte Restaurants (Issue #63):** Neue Sektion "Meine Einreichungen" auf der Profilseite zeigt vom Nutzer eingereichte Restaurants mit Verifizierungsstatus. Neues `submittedBy`-Feld auf der Restaurant-Entity (ManyToOne User, SET NULL). Bei Genehmigung eines Community-Vorschlags wird der Einreicher automatisch gesetzt. Übersetzungen in 4 Sprachen (de, en, fr, lb).
 - **Admin Dashboard Statistiken (Issue #62):** Erweitertes Dashboard mit 7 Stat-Karten (Restaurants, Verifizierte, Offene Vorschläge, Benutzer, Restaurants diesen Monat, Benutzer diesen Monat, Fotos). Tabellen für zuletzt hinzugefügte Restaurants und zuletzt registrierte Benutzer. Neuer `AdminStatsService` für zentralisierte Statistik-Abfragen. Dashboard-Route in eigenen `AdminDashboardController` ausgelagert. Übersetzungen in 4 Sprachen (de, en, fr, lb).
 - **Neue Lieferplattformen (Issue #67):** Wolt, Wedely und Goosty als Bestelloptionen. SVG-Logos für Marken-Plattformen auf der Detailseite. Emoji-Fallback für generische Optionen (Telefon, Webseite, Andere).
 - **Map:** Kartenansicht der Locations. *(geplant)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,15 @@ Controller: `ProfileController` — 4 Routen (`app_profile`, `app_profile_edit`,
 Template: `templates/profile/index.html.twig`, `templates/partials/_avatar.html.twig`.
 Migration: `Version20260317000000`.
 
+## Restaurant: submittedBy (Issue #63)
+Feld: `submittedBy` (ManyToOne User, nullable, SET NULL) — der Nutzer, der das Restaurant eingereicht hat.
+Getter/Setter: `getSubmittedBy()`, `setSubmittedBy()`.
+Repository: `RestaurantRepository::findBySubmitter(User $user): Restaurant[]` — alle Restaurants eines Einreichers, sortiert nach `createdAt DESC`.
+Profil-Template: Sektion "Meine Einreichungen" in `templates/profile/index.html.twig` — zeigt Emoji, Name (Link), Stadt, Datum, Verifizierungsstatus.
+Suggestion-Approval: `AdminSuggestionController::approve()` setzt `submittedBy` automatisch aus `suggestion.suggestedBy`.
+Migration: `Version20260319000000`.
+Fixtures: Admin → 3 verifizierte, User → 3 unverifizierte, Rest → null.
+
 ## Entity: OrderingOption (Issue #43)
 Felder: id (int, PK), platform (VARCHAR 20 – Werte aus `App\Enum\OrderingPlatform`), url (VARCHAR 500), restaurant (ManyToOne Restaurant, CASCADE DELETE).
 Collection auf Restaurant: `$orderingOptions` (OneToMany, cascade persist+remove, orphanRemoval).

--- a/migrations/Version20260319000000.php
+++ b/migrations/Version20260319000000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260319000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add submitted_by_id to restaurant table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE restaurant ADD submitted_by_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE restaurant ADD CONSTRAINT FK_EB95123F79F7D87D FOREIGN KEY (submitted_by_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_EB95123F79F7D87D ON restaurant (submitted_by_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE restaurant DROP FOREIGN KEY FK_EB95123F79F7D87D');
+        $this->addSql('DROP INDEX IDX_EB95123F79F7D87D ON restaurant');
+        $this->addSql('ALTER TABLE restaurant DROP submitted_by_id');
+    }
+}

--- a/src/Controller/AdminSuggestionController.php
+++ b/src/Controller/AdminSuggestionController.php
@@ -56,6 +56,7 @@ final class AdminSuggestionController extends AbstractController
         $restaurant->setHasAccessibleToilet($suggestion->hasAccessibleToilet());
         $restaurant->setAllowsAssistanceDogs($suggestion->allowsAssistanceDogs());
         $restaurant->setHasBrightLighting($suggestion->hasBrightLighting());
+        $restaurant->setSubmittedBy($suggestion->getSuggestedBy());
 
         $suggestion->setStatus(RestaurantSuggestion::STATUS_APPROVED);
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Form\ChangePasswordType;
 use App\Form\ProfileType;
+use App\Repository\RestaurantRepository;
 use App\Service\AvatarUploadService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -21,6 +22,7 @@ final class ProfileController extends AbstractController
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
+        private readonly RestaurantRepository $restaurantRepository,
     ) {
     }
 
@@ -38,6 +40,7 @@ final class ProfileController extends AbstractController
         return $this->render('profile/index.html.twig', [
             'profileForm' => $profileForm,
             'passwordForm' => $passwordForm,
+            'submittedRestaurants' => $this->restaurantRepository->findBySubmitter($this->getUser()),
         ]);
     }
 
@@ -68,6 +71,7 @@ final class ProfileController extends AbstractController
         return $this->render('profile/index.html.twig', [
             'profileForm' => $profileForm,
             'passwordForm' => $passwordForm,
+            'submittedRestaurants' => $this->restaurantRepository->findBySubmitter($this->getUser()),
         ]);
     }
 
@@ -103,6 +107,7 @@ final class ProfileController extends AbstractController
         return $this->render('profile/index.html.twig', [
             'profileForm' => $profileForm,
             'passwordForm' => $passwordForm,
+            'submittedRestaurants' => $this->restaurantRepository->findBySubmitter($this->getUser()),
         ]);
     }
 

--- a/src/DataFixtures/RestaurantFixtures.php
+++ b/src/DataFixtures/RestaurantFixtures.php
@@ -319,6 +319,16 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
             ],
         ];
 
+        // Zuordnung: Restaurant-Name → Submitter-Referenz
+        $submitterMap = [
+            'Pizzeria Bella Vista' => UserFixtures::REFERENCE_ADMIN,
+            'Sushi Zen'            => UserFixtures::REFERENCE_ADMIN,
+            'Green Bowl'           => UserFixtures::REFERENCE_ADMIN,
+            'Umami Corner'         => UserFixtures::REFERENCE_USER,
+            'Burger & Co.'         => UserFixtures::REFERENCE_USER,
+            'Café Nordstad'        => UserFixtures::REFERENCE_USER,
+        ];
+
         foreach ($restaurants as $data) {
             $restaurant = new Restaurant();
             $restaurant->setName($data['name']);
@@ -352,6 +362,10 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
             if ($isVerified) {
                 $restaurant->setVerifiedAt(new \DateTimeImmutable('2026-01-15'));
                 $restaurant->setVerifiedBy($this->getReference(UserFixtures::REFERENCE_ADMIN, User::class));
+            }
+
+            if (isset($submitterMap[$data['name']])) {
+                $restaurant->setSubmittedBy($this->getReference($submitterMap[$data['name']], User::class));
             }
 
             foreach ($data['orderingOptions'] ?? [] as [$platform, $url]) {

--- a/src/Entity/Restaurant.php
+++ b/src/Entity/Restaurant.php
@@ -77,6 +77,10 @@ class Restaurant
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
     private ?User $verifiedBy = null;
 
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $submittedBy = null;
+
     /** @var list<string> */
     #[ORM\Column(type: 'json')]
     private array $spokenLanguages = [];
@@ -403,6 +407,18 @@ class Restaurant
     public function setVerifiedBy(?User $verifiedBy): static
     {
         $this->verifiedBy = $verifiedBy;
+
+        return $this;
+    }
+
+    public function getSubmittedBy(): ?User
+    {
+        return $this->submittedBy;
+    }
+
+    public function setSubmittedBy(?User $submittedBy): static
+    {
+        $this->submittedBy = $submittedBy;
 
         return $this;
     }

--- a/src/Repository/RestaurantRepository.php
+++ b/src/Repository/RestaurantRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Restaurant;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
@@ -118,6 +119,19 @@ class RestaurantRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('r')
             ->orderBy('r.createdAt', 'DESC')
             ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return Restaurant[]
+     */
+    public function findBySubmitter(User $user): array
+    {
+        return $this->createQueryBuilder('r')
+            ->where('r.submittedBy = :user')
+            ->setParameter('user', $user)
+            ->orderBy('r.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -19,6 +19,42 @@
             </div>
         </div>
 
+        {# Meine Einreichungen #}
+        <div class="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+            <h2 class="text-lg font-bold text-gray-900 mb-6">{{ 'profile.section_submissions'|trans }}</h2>
+
+            {% if submittedRestaurants is not empty %}
+                <div class="space-y-4">
+                    {% for restaurant in submittedRestaurants %}
+                        <div class="flex items-center justify-between p-4 bg-gray-50 rounded-xl border border-gray-100">
+                            <div class="flex items-center gap-3 min-w-0">
+                                <span class="text-2xl flex-shrink-0">{{ restaurant.emoji }}</span>
+                                <div class="min-w-0">
+                                    <a href="{{ path('app_restaurant_show', {id: restaurant.id}) }}" class="text-sm font-semibold text-purple-700 hover:text-purple-900 transition truncate block">
+                                        {{ restaurant.name }}
+                                    </a>
+                                    <p class="text-xs text-gray-500 mt-0.5">
+                                        {{ restaurant.city }} · {{ 'profile.submitted_on'|trans({'%date%': restaurant.createdAt|date('d.m.Y')}) }}
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="flex-shrink-0 ml-4">
+                                {% if restaurant.isVerified %}
+                                    {% include 'partials/_verified_badge.html.twig' with {size: 'sm'} %}
+                                {% else %}
+                                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200">
+                                        ⏳ {{ 'profile.submission_pending'|trans }}
+                                    </span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <p class="text-sm text-gray-500">{{ 'profile.no_submissions'|trans }}</p>
+            {% endif %}
+        </div>
+
         {# Profil-Formular #}
         <div class="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
             <h2 class="text-lg font-bold text-gray-900 mb-6">{{ 'profile.section_info'|trans }}</h2>

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -552,6 +552,10 @@ profile:
     member_since: "Mitglied seit %date%"
     section_info: "Persönliche Daten"
     section_password: "Passwort ändern"
+    section_submissions: "Meine Einreichungen"
+    submitted_on: "Eingereicht am %date%"
+    submission_pending: "Ausstehend"
+    no_submissions: "Du hast noch keine Restaurants eingereicht. Schlage ein Restaurant vor und es erscheint hier, sobald es genehmigt wird!"
     form:
         avatar: "Profilbild"
         avatar_hint: "JPG, PNG oder WebP, max. 2 MB"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -552,6 +552,10 @@ profile:
     member_since: "Member since %date%"
     section_info: "Personal Information"
     section_password: "Change Password"
+    section_submissions: "My Submissions"
+    submitted_on: "Submitted on %date%"
+    submission_pending: "Pending"
+    no_submissions: "You haven't submitted any restaurants yet. Suggest a restaurant and it will appear here once approved!"
     form:
         avatar: "Profile Picture"
         avatar_hint: "JPG, PNG or WebP, max. 2 MB"

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -552,6 +552,10 @@ profile:
     member_since: "Membre depuis le %date%"
     section_info: "Données personnelles"
     section_password: "Modifier le mot de passe"
+    section_submissions: "Mes contributions"
+    submitted_on: "Soumis le %date%"
+    submission_pending: "En attente"
+    no_submissions: "Vous n'avez encore soumis aucun restaurant. Proposez un restaurant et il apparaîtra ici une fois approuvé !"
     form:
         avatar: "Photo de profil"
         avatar_hint: "JPG, PNG ou WebP, max. 2 Mo"

--- a/translations/messages.lb.yaml
+++ b/translations/messages.lb.yaml
@@ -552,6 +552,10 @@ profile:
     member_since: "Member säit %date%"
     section_info: "Perséinlech Donnéeën"
     section_password: "Passwuert änneren"
+    section_submissions: "Meng Abgaben"
+    submitted_on: "Agereecht den %date%"
+    submission_pending: "Aussteend"
+    no_submissions: "Du hues nach keng Restauranten agereecht. Schlo e Restaurant vir an et erschéngt hei, soubal et ugeholl gëtt!"
     form:
         avatar: "Profilbild"
         avatar_hint: "JPG, PNG oder WebP, max. 2 MB"


### PR DESCRIPTION
## Summary
- Neues `submittedBy`-Feld auf der Restaurant-Entity (ManyToOne User, SET NULL) mit Migration
- Sektion "Meine Einreichungen" auf der Profilseite (über Persönliche Daten) zeigt Emoji, Name-Link, Stadt, Datum und Verifizierungsstatus (Badge oder "Ausstehend")
- `AdminSuggestionController::approve()` setzt `submittedBy` automatisch aus dem Einreicher des Vorschlags
- Repository-Methode `findBySubmitter()`, Übersetzungen in 4 Sprachen (de, en, fr, lb), Fixtures für Admin (3 verifizierte) und User (3 unverifizierte)

## Test plan
- [x] Login als `user@endlech.lu` → `/profile` → 3 Restaurants sichtbar (Umami Corner, Burger & Co., Café Nordstad) mit "Ausstehend"-Badge
- [x] Login als `admin@endlech.lu` → `/profile` → 3 Restaurants sichtbar (Pizzeria Bella Vista, Sushi Zen, Green Bowl) mit Verifiziert-Badge
- [x] Login als `unverified@endlech.lu` → `/profile` → Empty State "Du hast noch keine Restaurants eingereicht…"
- [x] Restaurant-Links in der Einreichungsliste führen zur Detailseite
- [x] Einreichungen-Sektion steht über "Persönliche Daten"

🤖 Generated with [Claude Code](https://claude.com/claude-code)