### PR TITLE
Öffnungszeiten: Mehrere Zeitslots pro Tag (closes #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 ## [Unreleased]
 
 ### Added
+- **Öffnungszeiten: Mehrere Zeitslots pro Tag (Issue #81):** Restaurants mit zwei Schichten (z. B. Mittag 12:00–14:30 und Abend 18:00–22:00) werden jetzt korrekt abgebildet. Pro Wochentag sind beliebig viele `OpeningHour`-Einträge möglich; ein Tag ohne Zeitfenster gilt als geschlossen. Admin-Formular gruppiert die Slots nach Tag mit „＋ Zeitfenster hinzufügen"- und Entfernen-Buttons (Stimulus). Detailseite zeigt alle Slots eines Tages als `12:00 – 14:30 · 18:00 – 22:00`. Der „Geöffnet"-Status und die nächste Öffnungszeit berücksichtigen alle Slots (inkl. Nachtschicht-Übertrag). `?open=1`-Filter angepasst. Erster PHPUnit-Test (`OpeningHoursServiceTest`). Migration entfernt UNIQUE-Constraint und `is_closed`-Spalte.
 - **Map:** Kartenansicht der Locations. *(geplant)*
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ assets/
     └── app.css          # Tailwind import (@import "tailwindcss")
 
 migrations/              # Doctrine migrations (DoctrineMigrations namespace)
-tests/                   # PHPUnit tests (empty - MVP)
+tests/                   # PHPUnit tests (Service/OpeningHoursServiceTest)
 translations/            # i18n files (de, en, fr, lb)
 public/                  # Web root (index.php front controller)
 public/images/platforms/    # SVG logos for delivery platforms (Uber Eats, Deliveroo, etc.)
@@ -130,7 +130,7 @@ php bin/phpunit tests/              # Run specific directory
 
 PHPUnit is configured in `phpunit.dist.xml` with strict mode: fails on deprecation, notices, and warnings. Bootstrap loads `.env.test` variables.
 
-No test cases exist yet. When writing tests, use `App\Tests\` namespace (PSR-4 mapped to `tests/`).
+First test: `tests/Service/OpeningHoursServiceTest.php` (reiner Unit-Test ohne Kernel/DB). When writing tests, use `App\Tests\` namespace (PSR-4 mapped to `tests/`).
 
 ## Architecture & Conventions
 
@@ -224,18 +224,20 @@ Suggestion-Approval: `AdminSuggestionController::approve()` setzt `submittedBy` 
 Migration: `Version20260319000000`.
 Fixtures: Admin → 3 verifizierte, User → 3 unverifizierte, Rest → null.
 
-## Entity: OpeningHour (Issue #64)
-Felder: id, dayOfWeek (INT 1-7), openTime (TIME nullable), closeTime (TIME nullable), isClosed (BOOL), restaurant (ManyToOne CASCADE DELETE).
-UNIQUE: (restaurant_id, day_of_week).
-Collection auf Restaurant: `$openingHours` (OneToMany, cascade, orphanRemoval, OrderBy dayOfWeek ASC).
-Helper auf Restaurant: `getOpeningHourForDay(int $day): ?OpeningHour`.
-Service: `OpeningHoursService` — `isOpenNow()`, `isOpenAt()`, `getNextOpeningTime()`. Zeitzone: Europe/Luxembourg.
+## Entity: OpeningHour (Issue #64, erweitert in #81)
+Felder: id, dayOfWeek (INT 1-7), openTime (TIME nullable), closeTime (TIME nullable), restaurant (ManyToOne CASCADE DELETE).
+**Mehrere Zeitslots pro Tag** (Issue #81): kein UNIQUE-Constraint mehr; ein Tag kann beliebig viele `OpeningHour`-Einträge haben (z. B. Mittag + Abend). **Geschlossener Tag = keine Slots** (Feld `isClosed` entfernt).
+Collection auf Restaurant: `$openingHours` (OneToMany, cascade, orphanRemoval, OrderBy dayOfWeek ASC, openTime ASC).
+Helper auf Restaurant: `getOpeningHoursForDay(int $day): OpeningHour[]` — alle Slots eines Tages.
+Service: `OpeningHoursService` — `isOpenNow()`, `isOpenAt()` (iteriert über alle Slots), `getNextOpeningTime(Restaurant, ?\DateTimeInterface $now = null)` (frühester künftiger Slot; optionaler `$now` für Tests). Zeitzone: Europe/Luxembourg.
 Twig Extension: `OpeningHoursExtension` — Filter `restaurant|is_open_now`, Funktion `next_opening_time(restaurant)`.
-Form: `OpeningHourType` in CollectionType (fixed 7 Einträge, PRE_SET_DATA Listener füllt fehlende Tage auf).
-Stimulus: `opening_hours_form_controller.ts` — deaktiviert Zeitfelder bei "Geschlossen".
-Template: `templates/partials/_opening_hours.html.twig` — Wochenplan mit hervorgehobenem heutigem Tag.
-Filter: `?open=1` nutzt SQL JOIN mit TIME-Vergleich (inkl. Nachtschicht-Übertrag).
-Migration: `Version20260321000000` — erstellt `opening_hour` Tabelle, entfernt `is_open` Spalte.
+Form: `OpeningHourType` (dayOfWeek hidden, openTime/closeTime) als CollectionType (`allow_add`/`allow_delete`/`prototype`) in `RestaurantType`.
+Stimulus: `opening_hours_form_controller.ts` — pro Tag „＋ Zeitfenster hinzufügen" / einzelne Slots entfernen (Prototype-Klonen, gemeinsamer Index, setzt `dayOfWeek` des neuen Slots).
+Template: `templates/partials/_opening_hours.html.twig` — Wochenplan (Tag 1–7), mehrere Slots als `12:00 – 14:30 · 18:00 – 22:00`, hervorgehobener heutiger Tag.
+Admin-Template: `templates/admin/restaurant/_form.html.twig` — Öffnungszeiten nach Tag gruppiert.
+Filter: `?open=1` nutzt SQL JOIN mit TIME-Vergleich (inkl. Nachtschicht-Übertrag), `distinct()` gegen Duplikate bei mehreren Slots.
+Test: `tests/Service/OpeningHoursServiceTest.php` — Multi-Slot-, Nachtschicht- und Next-Opening-Logik.
+Migrationen: `Version20260321000000` (erstellt Tabelle), `Version20260619000000` (entfernt UNIQUE-Constraint + `is_closed`-Spalte für Multi-Slot).
 
 ## Nearby Stops / Public Transport (Issue #65)
 Felder auf Restaurant: `latitude` (DECIMAL 10,8 nullable), `longitude` (DECIMAL 11,8 nullable), `nearbyStopsNote` (TEXT nullable).

--- a/assets/controllers/opening_hours_form_controller.ts
+++ b/assets/controllers/opening_hours_form_controller.ts
@@ -41,7 +41,7 @@ export default class extends Controller {
             '✕</button>';
 
         // Den versteckten dayOfWeek-Input des neuen Slots auf den Zieltag setzen.
-        const dayInput = wrapper.querySelector<HTMLInputElement>('input[type="hidden"]');
+        const dayInput = wrapper.querySelector<HTMLInputElement>('input[type="hidden"][name*="[dayOfWeek]"]');
         if (dayInput) {
             dayInput.value = day;
         }

--- a/assets/controllers/opening_hours_form_controller.ts
+++ b/assets/controllers/opening_hours_form_controller.ts
@@ -1,36 +1,59 @@
 import { Controller } from '@hotwired/stimulus';
 
+/*
+ * Stimulus-Controller für die nach Wochentag gruppierten Öffnungszeiten-Slots.
+ * Erlaubt das Hinzufügen mehrerer Zeitslots pro Tag (z. B. Mittag + Abend)
+ * und das Entfernen einzelner Slots. Nutzt eine flache Symfony-CollectionType,
+ * deshalb wird ein gemeinsamer, über alle Tage eindeutiger Index geführt.
+ */
 export default class extends Controller {
-    static targets = ['row'];
+    static values = { prototype: String };
 
-    declare readonly rowTargets: HTMLElement[];
+    declare prototypeValue: string;
+
+    #index!: number;
 
     connect(): void {
-        this.rowTargets.forEach((row) => this.syncRow(row));
+        this.#index = this.element.querySelectorAll('[data-opening-hours-form-target="slot"]').length;
     }
 
-    toggle(event: Event): void {
-        const checkbox = event.target as HTMLInputElement;
-        const row = checkbox.closest('[data-opening-hours-form-target="row"]') as HTMLElement;
-        if (row) {
-            this.syncRow(row);
+    addSlot(event: Event): void {
+        const button = event.currentTarget as HTMLElement;
+        const day = button.dataset.openingHoursFormDayParam;
+        if (!day) {
+            return;
         }
+
+        const container = this.element.querySelector<HTMLElement>(`[data-day="${day}"]`);
+        if (!container) {
+            return;
+        }
+
+        const html = this.prototypeValue.replace(/__name__/g, String(this.#index));
+        this.#index++;
+
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('flex', 'items-center', 'gap-2');
+        wrapper.setAttribute('data-opening-hours-form-target', 'slot');
+        wrapper.innerHTML = html +
+            '<button type="button" data-action="opening-hours-form#removeSlot" ' +
+            'class="text-red-500 hover:text-red-700 text-sm font-bold px-2 py-1 shrink-0 transition">' +
+            '✕</button>';
+
+        // Den versteckten dayOfWeek-Input des neuen Slots auf den Zieltag setzen.
+        const dayInput = wrapper.querySelector<HTMLInputElement>('input[type="hidden"]');
+        if (dayInput) {
+            dayInput.value = day;
+        }
+
+        container.appendChild(wrapper);
     }
 
-    private syncRow(row: HTMLElement): void {
-        const checkbox = row.querySelector<HTMLInputElement>('input[type="checkbox"]');
-        const timeInputs = row.querySelectorAll<HTMLInputElement>('input[type="time"]');
-
-        if (checkbox && timeInputs.length > 0) {
-            const isClosed = checkbox.checked;
-            timeInputs.forEach((input) => {
-                input.disabled = isClosed;
-                if (isClosed) {
-                    input.classList.add('opacity-40');
-                } else {
-                    input.classList.remove('opacity-40');
-                }
-            });
+    removeSlot(event: Event): void {
+        const target = event.target as HTMLElement;
+        const slot = target.closest('[data-opening-hours-form-target="slot"]');
+        if (slot) {
+            slot.remove();
         }
     }
 }

--- a/migrations/Version20260619000000.php
+++ b/migrations/Version20260619000000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260619000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow multiple opening_hour slots per day: drop unique (restaurant, day) constraint and is_closed column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Geschlossene Tage werden im neuen Modell durch das Fehlen von Slots abgebildet.
+        $this->addSql('DELETE FROM opening_hour WHERE is_closed = 1');
+        $this->addSql('DROP INDEX unique_restaurant_day ON opening_hour');
+        $this->addSql('ALTER TABLE opening_hour DROP is_closed');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE opening_hour ADD is_closed TINYINT(1) DEFAULT 0 NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX unique_restaurant_day ON opening_hour (restaurant_id, day_of_week)');
+    }
+}

--- a/src/DataFixtures/RestaurantFixtures.php
+++ b/src/DataFixtures/RestaurantFixtures.php
@@ -143,7 +143,7 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'email'                  => 'reservierung@lejardin.lu',
                 'website'                => 'https://www.lejardin.lu',
                 'facebookUrl'            => 'https://facebook.com/lejardinbrasserie',
-                'openingHours'           => [[2, '12:00', '14:30'], [3, '12:00', '14:30'], [4, '12:00', '14:30'], [5, '12:00', '14:30'], [6, '12:00', '14:30']],
+                'openingHours'           => [[2, '12:00', '14:30'], [2, '18:00', '22:30'], [3, '12:00', '14:30'], [3, '18:00', '22:30'], [4, '12:00', '14:30'], [4, '18:00', '22:30'], [5, '12:00', '14:30'], [5, '18:00', '22:30'], [6, '12:00', '14:30'], [6, '18:00', '23:00'], [7, '12:00', '15:00']],
                 'orderingOptions'        => [
                     [OrderingPlatform::WOLT, 'https://wolt.com/lu/restaurant/le-jardin-brasserie'],
                 ],
@@ -171,7 +171,7 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'accessibilityNotes'     => ['warn:Zwei Stufen am Eingang', 'ok:Helle Innenbeleuchtung'],
                 'spokenLanguages'        => [Language::LU, Language::DE, Language::FR],
                 'phone'                  => '+352 75 11 22 33',
-                'openingHours'           => [[2, '17:00', '23:00'], [3, '17:00', '23:00'], [4, '17:00', '23:00'], [5, '17:00', '23:00'], [6, '17:00', '23:00'], [7, '12:00', '21:00']],
+                'openingHours'           => [[2, '17:00', '23:00'], [3, '17:00', '23:00'], [4, '17:00', '23:00'], [5, '17:00', '23:00'], [6, '12:00', '14:30'], [6, '18:00', '23:30'], [7, '12:00', '14:30'], [7, '18:00', '21:00']],
             ],
             [
                 'name'                   => 'Café Nordstad',
@@ -286,7 +286,7 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 'email'                  => 'ciao@trattoriaroma.lu',
                 'website'                => 'https://www.trattoriaroma.lu',
                 'instagramUrl'           => 'https://instagram.com/trattoriaroma.lu',
-                'openingHours'           => [[2, '11:00', '22:00'], [3, '11:00', '22:00'], [4, '11:00', '22:00'], [5, '11:00', '22:00'], [6, '11:00', '22:00'], [7, '11:00', '22:00']],
+                'openingHours'           => [[1, '12:00', '14:30'], [1, '18:30', '23:00'], [2, '12:00', '14:30'], [2, '18:30', '23:00'], [3, '12:00', '14:30'], [3, '18:30', '23:00'], [4, '12:00', '14:30'], [4, '18:30', '23:00'], [5, '12:00', '14:30'], [5, '18:30', '23:30'], [6, '18:30', '23:30'], [7, '12:00', '15:00']],
                 'orderingOptions'        => [
                     [OrderingPlatform::WEDELY, 'https://wedely.com/trattoria-roma'],
                 ],
@@ -418,7 +418,6 @@ class RestaurantFixtures extends Fixture implements DependentFixtureInterface
                 $oh->setDayOfWeek($day);
                 $oh->setOpenTime(new \DateTime($open));
                 $oh->setCloseTime(new \DateTime($close));
-                $oh->setIsClosed(false);
                 $restaurant->addOpeningHour($oh);
             }
 

--- a/src/Entity/OpeningHour.php
+++ b/src/Entity/OpeningHour.php
@@ -6,7 +6,6 @@ use App\Repository\OpeningHourRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: OpeningHourRepository::class)]
-#[ORM\UniqueConstraint(name: 'unique_restaurant_day', columns: ['restaurant_id', 'day_of_week'])]
 class OpeningHour
 {
     #[ORM\Id]
@@ -22,9 +21,6 @@ class OpeningHour
 
     #[ORM\Column(type: 'time', nullable: true)]
     private ?\DateTimeInterface $closeTime = null;
-
-    #[ORM\Column]
-    private bool $isClosed = false;
 
     #[ORM\ManyToOne(inversedBy: 'openingHours')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -67,18 +63,6 @@ class OpeningHour
     public function setCloseTime(?\DateTimeInterface $closeTime): static
     {
         $this->closeTime = $closeTime;
-
-        return $this;
-    }
-
-    public function isClosed(): bool
-    {
-        return $this->isClosed;
-    }
-
-    public function setIsClosed(bool $isClosed): static
-    {
-        $this->isClosed = $isClosed;
 
         return $this;
     }

--- a/src/Entity/Restaurant.php
+++ b/src/Entity/Restaurant.php
@@ -131,7 +131,7 @@ class Restaurant
 
     /** @var Collection<int, OpeningHour> */
     #[ORM\OneToMany(mappedBy: 'restaurant', targetEntity: OpeningHour::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
-    #[ORM\OrderBy(['dayOfWeek' => 'ASC'])]
+    #[ORM\OrderBy(['dayOfWeek' => 'ASC', 'openTime' => 'ASC'])]
     private Collection $openingHours;
 
     public function __construct()
@@ -645,14 +645,18 @@ class Restaurant
         return $this;
     }
 
-    public function getOpeningHourForDay(int $day): ?OpeningHour
+    /**
+     * @return OpeningHour[]
+     */
+    public function getOpeningHoursForDay(int $day): array
     {
+        $slots = [];
         foreach ($this->openingHours as $oh) {
             if ($oh->getDayOfWeek() === $day) {
-                return $oh;
+                $slots[] = $oh;
             }
         }
 
-        return null;
+        return $slots;
     }
 }

--- a/src/Form/OpeningHourType.php
+++ b/src/Form/OpeningHourType.php
@@ -4,7 +4,6 @@ namespace App\Form;
 
 use App\Entity\OpeningHour;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -14,18 +13,19 @@ class OpeningHourType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $timeAttr = ['class' => 'bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none w-32'];
+
         $builder
             ->add('dayOfWeek', HiddenType::class)
             ->add('openTime', TimeType::class, [
                 'widget' => 'single_text',
                 'required' => false,
+                'attr' => $timeAttr,
             ])
             ->add('closeTime', TimeType::class, [
                 'widget' => 'single_text',
                 'required' => false,
-            ])
-            ->add('isClosed', CheckboxType::class, [
-                'required' => false,
+                'attr' => $timeAttr,
             ]);
     }
 

--- a/src/Form/RestaurantType.php
+++ b/src/Form/RestaurantType.php
@@ -3,7 +3,6 @@
 namespace App\Form;
 
 use App\Entity\Cuisine;
-use App\Entity\OpeningHour;
 use App\Entity\Restaurant;
 use App\Enum\Language;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -14,8 +13,6 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
@@ -251,9 +248,11 @@ class RestaurantType extends AbstractType
             ->add('openingHours', CollectionType::class, [
                 'label' => 'admin.form.opening_hours',
                 'entry_type' => OpeningHourType::class,
-                'allow_add' => false,
-                'allow_delete' => false,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'prototype' => true,
                 'by_reference' => false,
+                'required' => false,
                 'constraints' => [
                     new Valid(),
                 ],
@@ -276,28 +275,6 @@ class RestaurantType extends AbstractType
                 'prototype' => true,
                 'required' => false,
             ]);
-
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-            /** @var Restaurant|null $restaurant */
-            $restaurant = $event->getData();
-            if ($restaurant === null) {
-                return;
-            }
-
-            $existingDays = [];
-            foreach ($restaurant->getOpeningHours() as $oh) {
-                $existingDays[$oh->getDayOfWeek()] = true;
-            }
-
-            for ($day = 1; $day <= 7; ++$day) {
-                if (!isset($existingDays[$day])) {
-                    $oh = new OpeningHour();
-                    $oh->setDayOfWeek($day);
-                    $oh->setIsClosed(true);
-                    $restaurant->addOpeningHour($oh);
-                }
-            }
-        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Repository/RestaurantRepository.php
+++ b/src/Repository/RestaurantRepository.php
@@ -73,12 +73,13 @@ class RestaurantRepository extends ServiceEntityRepository
             $qb->leftJoin('r.openingHours', 'oh_today', 'WITH', 'oh_today.dayOfWeek = :currentDay')
                 ->leftJoin('r.openingHours', 'oh_yesterday', 'WITH', 'oh_yesterday.dayOfWeek = :previousDay')
                 ->andWhere(
-                    '(oh_today.isClosed = false AND oh_today.openTime <= oh_today.closeTime AND oh_today.openTime <= :currentTime AND oh_today.closeTime > :currentTime)' .
+                    '(oh_today.openTime <= oh_today.closeTime AND oh_today.openTime <= :currentTime AND oh_today.closeTime > :currentTime)' .
                     ' OR ' .
-                    '(oh_today.isClosed = false AND oh_today.openTime > oh_today.closeTime AND oh_today.openTime <= :currentTime)' .
+                    '(oh_today.openTime > oh_today.closeTime AND oh_today.openTime <= :currentTime)' .
                     ' OR ' .
-                    '(oh_yesterday.isClosed = false AND oh_yesterday.openTime > oh_yesterday.closeTime AND oh_yesterday.closeTime > :currentTime)'
+                    '(oh_yesterday.openTime > oh_yesterday.closeTime AND oh_yesterday.closeTime > :currentTime)'
                 )
+                ->distinct()
                 ->setParameter('currentDay', $currentDay)
                 ->setParameter('previousDay', $previousDay)
                 ->setParameter('currentTime', $currentTime);

--- a/src/Service/OpeningHoursService.php
+++ b/src/Service/OpeningHoursService.php
@@ -21,11 +21,13 @@ class OpeningHoursService
         $currentDay = (int) $dt->format('N');
         $currentTime = $dt->format('H:i:s');
 
-        $todayEntry = $restaurant->getOpeningHourForDay($currentDay);
+        foreach ($restaurant->getOpeningHoursForDay($currentDay) as $slot) {
+            if ($slot->getOpenTime() === null || $slot->getCloseTime() === null) {
+                continue;
+            }
 
-        if ($todayEntry !== null && !$todayEntry->isClosed() && $todayEntry->getOpenTime() !== null && $todayEntry->getCloseTime() !== null) {
-            $open = $todayEntry->getOpenTime()->format('H:i:s');
-            $close = $todayEntry->getCloseTime()->format('H:i:s');
+            $open = $slot->getOpenTime()->format('H:i:s');
+            $close = $slot->getCloseTime()->format('H:i:s');
 
             if ($open <= $close) {
                 if ($currentTime >= $open && $currentTime < $close) {
@@ -39,11 +41,14 @@ class OpeningHoursService
         }
 
         $previousDay = $currentDay === 1 ? 7 : $currentDay - 1;
-        $yesterdayEntry = $restaurant->getOpeningHourForDay($previousDay);
 
-        if ($yesterdayEntry !== null && !$yesterdayEntry->isClosed() && $yesterdayEntry->getOpenTime() !== null && $yesterdayEntry->getCloseTime() !== null) {
-            $open = $yesterdayEntry->getOpenTime()->format('H:i:s');
-            $close = $yesterdayEntry->getCloseTime()->format('H:i:s');
+        foreach ($restaurant->getOpeningHoursForDay($previousDay) as $slot) {
+            if ($slot->getOpenTime() === null || $slot->getCloseTime() === null) {
+                continue;
+            }
+
+            $open = $slot->getOpenTime()->format('H:i:s');
+            $close = $slot->getCloseTime()->format('H:i:s');
 
             if ($open > $close && $currentTime < $close) {
                 return true;
@@ -56,36 +61,49 @@ class OpeningHoursService
     /**
      * @return array{dayOfWeek: int, time: \DateTimeInterface}|null
      */
-    public function getNextOpeningTime(Restaurant $restaurant): ?array
+    public function getNextOpeningTime(Restaurant $restaurant, ?\DateTimeInterface $now = null): ?array
     {
-        if ($this->isOpenNow($restaurant)) {
+        $tz = new \DateTimeZone(self::TIMEZONE);
+        $reference = $now !== null
+            ? \DateTimeImmutable::createFromInterface($now)->setTimezone($tz)
+            : new \DateTimeImmutable('now', $tz);
+
+        if ($this->isOpenAt($restaurant, $reference)) {
             return null;
         }
 
-        $tz = new \DateTimeZone(self::TIMEZONE);
-        $now = new \DateTimeImmutable('now', $tz);
-        $currentDay = (int) $now->format('N');
-        $currentTime = $now->format('H:i:s');
+        $currentDay = (int) $reference->format('N');
+        $currentTime = $reference->format('H:i:s');
 
-        $todayEntry = $restaurant->getOpeningHourForDay($currentDay);
-        if ($todayEntry !== null && !$todayEntry->isClosed() && $todayEntry->getOpenTime() !== null) {
-            $openTime = $todayEntry->getOpenTime()->format('H:i:s');
-            if ($openTime > $currentTime) {
-                return [
-                    'dayOfWeek' => $currentDay,
-                    'time' => $todayEntry->getOpenTime(),
-                ];
+        // Heute: frühester Slot, der noch öffnet.
+        $nextToday = null;
+        foreach ($restaurant->getOpeningHoursForDay($currentDay) as $slot) {
+            if ($slot->getOpenTime() === null) {
+                continue;
+            }
+            $openTime = $slot->getOpenTime()->format('H:i:s');
+            if ($openTime > $currentTime && ($nextToday === null || $openTime < $nextToday->format('H:i:s'))) {
+                $nextToday = $slot->getOpenTime();
             }
         }
+        if ($nextToday !== null) {
+            return ['dayOfWeek' => $currentDay, 'time' => $nextToday];
+        }
 
+        // Folgetage: erster Tag mit Slots, dessen frühester Slot.
         for ($i = 1; $i <= 6; ++$i) {
             $day = (($currentDay - 1 + $i) % 7) + 1;
-            $entry = $restaurant->getOpeningHourForDay($day);
-            if ($entry !== null && !$entry->isClosed() && $entry->getOpenTime() !== null) {
-                return [
-                    'dayOfWeek' => $day,
-                    'time' => $entry->getOpenTime(),
-                ];
+            $earliest = null;
+            foreach ($restaurant->getOpeningHoursForDay($day) as $slot) {
+                if ($slot->getOpenTime() === null) {
+                    continue;
+                }
+                if ($earliest === null || $slot->getOpenTime()->format('H:i:s') < $earliest->format('H:i:s')) {
+                    $earliest = $slot->getOpenTime();
+                }
+            }
+            if ($earliest !== null) {
+                return ['dayOfWeek' => $day, 'time' => $earliest];
             }
         }
 

--- a/templates/admin/restaurant/_form.html.twig
+++ b/templates/admin/restaurant/_form.html.twig
@@ -51,26 +51,40 @@
         </label>
     </fieldset>
 
-    {# --- Öffnungszeiten --- #}
+    {# --- Öffnungszeiten (mehrere Zeitslots pro Tag) --- #}
     <fieldset>
         <legend class="text-lg font-bold text-gray-700 border-b border-gray-200 pb-2 mb-4">{{ 'admin.form.opening_hours'|trans }}</legend>
         <p class="text-xs text-gray-400 mb-3">{{ 'admin.form.opening_hours_hint'|trans }}</p>
 
-        <div data-controller="opening-hours-form" class="space-y-2">
-            {% set dayNames = {1: 'opening_hours.day_1', 2: 'opening_hours.day_2', 3: 'opening_hours.day_3', 4: 'opening_hours.day_4', 5: 'opening_hours.day_5', 6: 'opening_hours.day_6', 7: 'opening_hours.day_7'} %}
-            {% for oh in form.openingHours %}
-                {{ form_widget(oh.dayOfWeek) }}
-                <div class="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200" data-opening-hours-form-target="row">
-                    <span class="text-sm font-semibold text-gray-700 w-24 shrink-0">{{ dayNames[oh.vars.data.dayOfWeek]|trans }}</span>
-                    <div class="flex items-center gap-2 flex-1">
-                        {{ form_widget(oh.openTime, {'attr': {'class': 'bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none w-32'}}) }}
-                        <span class="text-gray-400 text-sm">–</span>
-                        {{ form_widget(oh.closeTime, {'attr': {'class': 'bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-500 focus:outline-none w-32'}}) }}
+        <div data-controller="opening-hours-form"
+             data-opening-hours-form-prototype-value="{{ form_widget(form.openingHours.vars.prototype)|e('html_attr') }}"
+             class="space-y-3">
+            {% for day in 1..7 %}
+                <div class="p-3 bg-gray-50 rounded-lg border border-gray-200">
+                    <div class="flex items-center justify-between mb-2">
+                        <span class="text-sm font-semibold text-gray-700">{{ ('opening_hours.day_' ~ day)|trans }}</span>
+                        <button type="button" data-action="opening-hours-form#addSlot"
+                                data-opening-hours-form-day-param="{{ day }}"
+                                class="text-sm font-semibold text-purple-600 hover:text-purple-800 transition">
+                            {{ 'admin.form.add_opening_slot'|trans }}
+                        </button>
                     </div>
-                    <label class="flex items-center gap-2 cursor-pointer group shrink-0">
-                        {{ form_widget(oh.isClosed, {'attr': {'class': 'rounded text-red-500 focus:ring-red-400 border-gray-300', 'data-action': 'opening-hours-form#toggle'}}) }}
-                        <span class="text-xs text-gray-500 group-hover:text-red-600">{{ 'opening_hours.closed'|trans }}</span>
-                    </label>
+                    <div data-day="{{ day }}" class="space-y-2">
+                        {% for slot in form.openingHours %}
+                            {% if slot.vars.data.dayOfWeek == day %}
+                                <div class="flex items-center gap-2" data-opening-hours-form-target="slot">
+                                    {{ form_widget(slot.dayOfWeek) }}
+                                    {{ form_widget(slot.openTime) }}
+                                    <span class="text-gray-400 text-sm">–</span>
+                                    {{ form_widget(slot.closeTime) }}
+                                    <button type="button" data-action="opening-hours-form#removeSlot"
+                                            class="text-red-500 hover:text-red-700 text-sm font-bold px-2 py-1 shrink-0 transition">
+                                        ✕
+                                    </button>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
                 </div>
             {% endfor %}
         </div>

--- a/templates/partials/_opening_hours.html.twig
+++ b/templates/partials/_opening_hours.html.twig
@@ -3,20 +3,25 @@
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
         <h2 class="text-lg font-bold text-gray-800 mb-4">{{ 'opening_hours.title'|trans }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {% for oh in restaurant.openingHours %}
-                {% set isToday = (oh.dayOfWeek == todayDayOfWeek) %}
+            {% for day in 1..7 %}
+                {% set isToday = (day == todayDayOfWeek) %}
+                {% set slots = restaurant.getOpeningHoursForDay(day) %}
                 <div class="flex items-center justify-between px-3 py-2 rounded-lg {{ isToday ? 'bg-purple-50 border border-purple-200' : 'bg-gray-50 border border-gray-100' }}">
                     <span class="text-sm font-semibold {{ isToday ? 'text-purple-700' : 'text-gray-700' }}">
-                        {{ ('opening_hours.day_' ~ oh.dayOfWeek)|trans }}
+                        {{ ('opening_hours.day_' ~ day)|trans }}
                         {% if isToday %}
                             <span class="text-xs font-normal text-purple-500 ml-1">({{ 'opening_hours.today'|trans }})</span>
                         {% endif %}
                     </span>
                     <span class="text-sm {{ isToday ? 'text-purple-600 font-medium' : 'text-gray-500' }}">
-                        {% if oh.isClosed or oh.openTime is null %}
+                        {% if slots is empty %}
                             {{ 'opening_hours.closed'|trans }}
                         {% else %}
-                            {{ oh.openTime|date('H:i') }} – {{ oh.closeTime|date('H:i') }}
+                            {% for slot in slots %}
+                                {%- if slot.openTime and slot.closeTime -%}
+                                    {{ slot.openTime|date('H:i') }} – {{ slot.closeTime|date('H:i') }}{% if not loop.last %} · {% endif %}
+                                {%- endif -%}
+                            {% endfor %}
                         {% endif %}
                     </span>
                 </div>

--- a/tests/Service/OpeningHoursServiceTest.php
+++ b/tests/Service/OpeningHoursServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\OpeningHour;
+use App\Entity\Restaurant;
+use App\Service\OpeningHoursService;
+use PHPUnit\Framework\TestCase;
+
+class OpeningHoursServiceTest extends TestCase
+{
+    private const TZ = 'Europe/Luxembourg';
+
+    private function slot(int $day, string $open, string $close): OpeningHour
+    {
+        $oh = new OpeningHour();
+        $oh->setDayOfWeek($day);
+        $oh->setOpenTime(new \DateTime($open));
+        $oh->setCloseTime(new \DateTime($close));
+
+        return $oh;
+    }
+
+    private function at(string $datetime): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable($datetime, new \DateTimeZone(self::TZ));
+    }
+
+    public function testOpenDuringLunchSlot(): void
+    {
+        $restaurant = new Restaurant();
+        // Mittwoch (3): Mittag 12:00–14:30, Abend 18:00–22:00
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+
+        $service = new OpeningHoursService();
+
+        // 2026-06-17 ist ein Mittwoch.
+        self::assertTrue($service->isOpenAt($restaurant, $this->at('2026-06-17 13:00')));
+    }
+
+    public function testClosedInGapBetweenSlots(): void
+    {
+        $restaurant = new Restaurant();
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+
+        $service = new OpeningHoursService();
+
+        self::assertFalse($service->isOpenAt($restaurant, $this->at('2026-06-17 16:00')));
+    }
+
+    public function testOpenDuringDinnerSlot(): void
+    {
+        $restaurant = new Restaurant();
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+
+        $service = new OpeningHoursService();
+
+        self::assertTrue($service->isOpenAt($restaurant, $this->at('2026-06-17 19:00')));
+    }
+
+    public function testOvernightSlotSpillsIntoNextDay(): void
+    {
+        $restaurant = new Restaurant();
+        // Freitag (5): 18:00–01:00 (Nachtschicht)
+        $restaurant->addOpeningHour($this->slot(5, '18:00', '01:00'));
+
+        $service = new OpeningHoursService();
+
+        // 2026-06-20 00:30 ist Samstag früh – die Freitag-Nachtschicht läuft noch.
+        self::assertTrue($service->isOpenAt($restaurant, $this->at('2026-06-20 00:30')));
+        // Samstag 02:00 ist geschlossen.
+        self::assertFalse($service->isOpenAt($restaurant, $this->at('2026-06-20 02:00')));
+    }
+
+    public function testNextOpeningTimeIsNextSlotSameDay(): void
+    {
+        $restaurant = new Restaurant();
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+
+        $service = new OpeningHoursService();
+
+        $next = $service->getNextOpeningTime($restaurant, $this->at('2026-06-17 16:00'));
+
+        self::assertNotNull($next);
+        self::assertSame(3, $next['dayOfWeek']);
+        self::assertSame('18:00', $next['time']->format('H:i'));
+    }
+
+    public function testNextOpeningTimeRollsToFollowingDay(): void
+    {
+        $restaurant = new Restaurant();
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+        // Donnerstag (4): nur Mittag
+        $restaurant->addOpeningHour($this->slot(4, '12:00', '14:30'));
+
+        $service = new OpeningHoursService();
+
+        // Mittwoch 23:00 – heute schon vorbei, nächster offener Slot ist Donnerstag 12:00.
+        $next = $service->getNextOpeningTime($restaurant, $this->at('2026-06-17 23:00'));
+
+        self::assertNotNull($next);
+        self::assertSame(4, $next['dayOfWeek']);
+        self::assertSame('12:00', $next['time']->format('H:i'));
+    }
+
+    public function testDayWithoutSlotsIsClosed(): void
+    {
+        $restaurant = new Restaurant();
+        // Nur Mittwoch gepflegt – Donnerstag hat keine Slots.
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+
+        $service = new OpeningHoursService();
+
+        // 2026-06-18 ist Donnerstag.
+        self::assertFalse($service->isOpenAt($restaurant, $this->at('2026-06-18 13:00')));
+    }
+}

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -421,7 +421,8 @@ admin:
         location: "Standort & Nahverkehr"
         location_hint: "GPS-Koordinaten ermöglichen die automatische Suche nach barrierefreien Haltestellen in der Nähe."
         opening_hours: "Öffnungszeiten"
-        opening_hours_hint: "Gib die Öffnungszeiten für jeden Tag ein. Aktiviere 'Geschlossen' für Ruhetage."
+        opening_hours_hint: "Füge pro Tag beliebig viele Zeitfenster hinzu (z. B. Mittag und Abend). Ein Tag ohne Zeitfenster gilt als geschlossen."
+        add_opening_slot: "＋ Zeitfenster hinzufügen"
         cancel: "Abbrechen"
     suggestion:
         title: "Restaurant-Vorschläge"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -421,7 +421,8 @@ admin:
         location: "Location & Public Transport"
         location_hint: "GPS coordinates enable automatic search for accessible stops nearby."
         opening_hours: "Opening Hours"
-        opening_hours_hint: "Enter the opening hours for each day. Check 'Closed' for rest days."
+        opening_hours_hint: "Add as many time slots per day as needed (e.g. lunch and dinner). A day without any slot counts as closed."
+        add_opening_slot: "＋ Add time slot"
         cancel: "Cancel"
     suggestion:
         title: "Restaurant Suggestions"

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -421,7 +421,8 @@ admin:
         location: "Localisation & Transports"
         location_hint: "Les coordonnées GPS permettent la recherche automatique d'arrêts accessibles à proximité."
         opening_hours: "Horaires d'ouverture"
-        opening_hours_hint: "Entrez les horaires d'ouverture pour chaque jour. Cochez 'Fermé' pour les jours de repos."
+        opening_hours_hint: "Ajoutez autant de créneaux que nécessaire par jour (p. ex. midi et soir). Un jour sans créneau est considéré comme fermé."
+        add_opening_slot: "＋ Ajouter un créneau"
         cancel: "Annuler"
     suggestion:
         title: "Propositions de restaurants"

--- a/translations/messages.lb.yaml
+++ b/translations/messages.lb.yaml
@@ -421,7 +421,8 @@ admin:
         location: "Standuert & Nahverkéier"
         location_hint: "GPS-Koordinaten erlaben d'automatesch Sich no barrierefrä Haltestellen an der Géigend."
         opening_hours: "Öffnungszäiten"
-        opening_hours_hint: "Gëff d'Öffnungszäiten fir all Dag an. Aktivéier 'Zou' fir Roudeg."
+        opening_hours_hint: "Setz pro Dag esou vill Zäitfenstere bäi wéi néideg (z. B. Mëtteg an Owend). En Dag ouni Zäitfenster gëllt als zou."
+        add_opening_slot: "＋ Zäitfenster derbäisetzen"
         cancel: "Ofbriechen"
     suggestion:
         title: "Restaurant-Virschléi"


### PR DESCRIPTION
## Kontext
Viele Restaurants in Luxemburg arbeiten in **zwei Schichten pro Tag** (z. B. Mittag 12:00–14:30, Abend 18:00–22:00). Bisher erlaubte ein UNIQUE-Constraint `(restaurant_id, day_of_week)` nur **einen Slot pro Tag** – Restaurants erschienen fälschlich als geschlossen, wenn sie später wieder öffnen. Schließt #81.

## Änderungen
**Datenmodell**
- `OpeningHour`: UNIQUE-Constraint und Feld `isClosed` entfernt → beliebig viele Slots pro Tag. **Geschlossener Tag = keine Slots.**
- `Restaurant`: OrderBy `dayOfWeek ASC, openTime ASC`; neuer Helper `getOpeningHoursForDay(int): OpeningHour[]` (ersetzt `getOpeningHourForDay()`).
- Migration `Version20260619000000`: löscht `is_closed=1`-Zeilen, entfernt Index + Spalte (inkl. `down()`).

**Logik**
- `OpeningHoursService::isOpenAt()` iteriert über alle Slots des Tages (+ Vortag für Nachtschicht-Übertrag).
- `getNextOpeningTime()` wählt den frühesten künftigen Slot; optionaler `$now`-Parameter für deterministische Tests.
- Repository-Filter `?open=1`: `isClosed`-Bedingungen entfernt, `distinct()` gegen Duplikate.

**UI**
- Admin-Formular nach Tag gruppiert mit „＋ Zeitfenster hinzufügen"- und Entfernen-Buttons. Stimulus-Controller `opening_hours_form_controller.ts` neu (Prototype-Klonen mit gemeinsamem Index, setzt `dayOfWeek`).
- Detailseite: vollständige Wochenansicht, mehrere Slots als `12:00 – 14:30 · 18:00 – 22:00`, heutiger Tag hervorgehoben.
- Übersetzungen de/en/fr/lb.

**Daten & Tests**
- Fixtures: 3 Restaurants auf Zwei-Schicht-Betrieb umgestellt (Le Jardin Brasserie, Trattoria Roma, Steakhaus Moselle am WE); Nachtschicht-Beispiel bleibt.
- Erster PHPUnit-Test `tests/Service/OpeningHoursServiceTest.php` (7 Tests).

## Acceptance Criteria
- [x] Mehrere `OpeningHour`-Einträge pro Tag pro Restaurant
- [x] `OpeningHoursService` behandelt mehrere Slots korrekt
- [x] Admin-Panel: Slots pro Tag hinzufügen/entfernen
- [x] Detailseite zeigt alle Slots lesbar
- [x] „Geöffnet"-Badge spiegelt aktiven Slot wider
- [x] Nächste Öffnungszeit korrekt, wenn alle Slots des Tages vorbei
- [x] Fixtures mit Multi-Slot-Restaurants

## Verifikation
- ✅ `php -l`, Doctrine-Mapping valid, PHPUnit 7/7, `npm run typecheck` + `lint`, Twig- & YAML-Lint
- ⏳ Vor dem Merge lokal: `make db && make fixtures` (oder `make db-reset`), dann Admin-Formular + Multi-Slot-Detailseite + `/restaurants?open=1` prüfen (Docker war beim Erstellen nicht verfügbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)