### PR TITLE
Fix: Koordinaten im Admin-Formular mit voller Präzision anzeigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ## [Unreleased]
 
+### Fixed
+- **Admin – Koordinaten-Präzision:** Breiten- und Längengrad im Restaurant-Formular werden nicht mehr auf 3 Nachkommastellen gerundet angezeigt (z. B. `5.94700000` → `5,947`), sondern mit voller Präzision von 8 Nachkommastellen – passend zu den DB-Spalten `DECIMAL(10,8)`/`DECIMAL(11,8)`. Ursache war der fehlende `scale`-Wert auf den `NumberType`-Feldern (`RestaurantType`); Default des `\NumberFormatter` sind 3 Nachkommastellen. Schützt auch beim Speichern vor Präzisionsverlust.
+
 - **Map:** Kartenansicht der Locations. *(geplant)*
 
 ---

--- a/src/Form/RestaurantType.php
+++ b/src/Form/RestaurantType.php
@@ -203,6 +203,7 @@ class RestaurantType extends AbstractType
                 'label' => 'form.latitude',
                 'required' => false,
                 'html5' => true,
+                'scale' => 8,
                 'attr' => ['placeholder' => 'form.latitude_placeholder', 'step' => '0.00000001'],
                 'constraints' => [
                     new Range(
@@ -216,6 +217,7 @@ class RestaurantType extends AbstractType
                 'label' => 'form.longitude',
                 'required' => false,
                 'html5' => true,
+                'scale' => 8,
                 'attr' => ['placeholder' => 'form.longitude_placeholder', 'step' => '0.00000001'],
                 'constraints' => [
                     new Range(


### PR DESCRIPTION
## Problem

Beim Bearbeiten/Anlegen eines Lokals wurden die Koordinaten-Werte im Admin-Restaurant-Formular gerundet angezeigt — z. B. `5.94700000` erschien als `5,947` (auf **3 Nachkommastellen** gekürzt). Dadurch ging Präzision verloren und konnte beim Speichern überschrieben werden.

## Ursache

Die Felder `latitude` und `longitude` in `src/Form/RestaurantType.php` nutzten `NumberType` **ohne** `scale`-Option. Bei `scale => null` rundet Symfonys `\NumberFormatter` (DECIMAL) standardmäßig auf 3 Nachkommastellen. Die DB-Spalten sind aber `DECIMAL(10,8)` (lat) bzw. `DECIMAL(11,8)` (lng) — also 8 Nachkommastellen.

## Fix

`'scale' => 8` auf beiden Feldern ergänzt, passend zur DB-Präzision. Keine Entity-/Migrations-/DB-Änderung nötig.

## Verifikation

Im laufenden Dev-Server als Admin verifiziert (Restaurant „Umami Corner", `longitude 5.94700000`):

```html
<input type="number" id="restaurant_latitude"  … value="49.50200000" />
<input type="number" id="restaurant_longitude" … value="5.94700000" />
```

Volle 8 Nachkommastellen statt vorher auf 3 gerundet. `php -l` ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)