### PR TITLE
Test-Suite ausbauen (29→146 Tests) inkl. Infrastruktur, CI & 3 Bugfixes

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,10 @@ APP_SECRET='$ecretf0rt3st'
 # Test-Datenbank (gleicher MySQL wie Dev; dbname_suffix _test wird automatisch angehängt).
 # .env.local wird im Test-Env per Symfony-Konvention NICHT geladen.
 DATABASE_URL="mysql://root:root@127.0.0.1:3306/endlech?serverVersion=8.0&charset=utf8mb4"
+
+# E-Mails im Test nicht real versenden (Mailer-Routing ist sync, siehe messenger.yaml).
+MAILER_DSN=null://null
+
+# Kein Nahverkehrs-API-Key im Test: PublicTransportService liefert sofort [] zurück
+# (keine echten HAFAS-HTTP-Calls in RestaurantController::show-Tests).
+MOBILITEIT_API_KEY=''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+
+jobs:
+  tests:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4']
+
+    services:
+      database:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ctype, iconv, intl, mbstring, pdo_mysql, gd
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-publish
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Generate JWT keypair
+        run: php bin/console lexik:jwt:generate-keypair --env=test --skip-if-exists
+
+      - name: Prepare test database
+        run: |
+          php bin/console doctrine:database:create --env=test --if-not-exists
+          php bin/console doctrine:migrations:migrate --env=test --no-interaction
+          php bin/console doctrine:fixtures:load --env=test --no-interaction
+
+      - name: Run PHPUnit
+        run: php bin/phpunit
+
+  frontend:
+    name: TypeScript & ESLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries=10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
         run: composer validate --no-check-publish
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/composer
           key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
           restore-keys: composer-${{ runner.os }}-
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        # --no-scripts: Auto-Scripts (cache:clear/assets) brauchen ein dev-DATABASE_URL,
+        # das nur in der gitignorierten .env.local liegt. Für Tests irrelevant – die
+        # --env=test-Befehle bauen den Test-Cache selbst (DATABASE_URL aus .env.test).
+        run: composer install --no-interaction --no-progress --prefer-dist --no-scripts
 
       - name: Generate JWT keypair
         run: php bin/console lexik:jwt:generate-keypair --env=test --skip-if-exists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           tools: composer:v2
 
       - name: Validate composer.json
-        run: composer validate --strict --no-check-publish
+        run: composer validate --no-check-publish
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ## [Unreleased]
 
+### Added
+- **Umfassende Test-Suite & CI:** Die automatisierte Testabdeckung wurde von 29 auf **146 Tests** (474 Assertions) ausgebaut – Unit-Tests (Services, Transformer, Enums, Twig-Extension), Integrationstests gegen MySQL (alle `RestaurantRepository::findPaginated`-Filter inkl. Nachtschicht- und `JSON_CONTAINS`-Logik, Upload-Services mit Temp-Dir-Isolation) und funktionale WebTestCase-Tests für sämtliche Web-, Admin- und `/api/v1`-Controller (inkl. Auth-Guards, CSRF-Pfade, Mailer-Versand). Test-Isolation über `dama/doctrine-test-bundle` (Transaktion-Rollback pro Test → wiederholbare Läufe). Neue Befehle `make test` / `make test-db-setup` und `composer test`. GitHub-Actions-Workflow (`.github/workflows/ci.yml`) führt PHPUnit (PHP 8.4 + MySQL-8.0-Service, JWT-Keypair) sowie TypeScript-Typecheck und ESLint bei jedem Push/PR aus. Basisklasse `tests/AbstractWebTestCase.php` mit Login-/Formular-/CSRF-Helfern.
+
 ### Fixed
+- **Sprachen-Filter (`?lang_…`) warf 500er:** Der dokumentierte Sprachfilter auf `/restaurants` (z. B. `?lang_de=1`) nutzt die MySQL-Funktion `JSON_CONTAINS`, die nirgends als DQL-Funktion registriert war → `QueryException`. Neu: `App\Doctrine\JsonContainsFunction`, registriert in `config/packages/doctrine.yaml`.
+- **Restaurant-Detailseite warf 500er ohne Nahverkehrs-API-Key:** `app.mobiliteit_api_key` löste über `%env(default::…)%` bei leerem Key zu `null` auf, was den `string`-Typehint von `PublicTransportService` brach (jede Detailseite mit Koordinaten betroffen). Fix: `%env(string:default::MOBILITEIT_API_KEY)%` castet zu `''` → dokumentierte Graceful-Degradation (leerer Key → keine Haltestellen) funktioniert wieder.
+- **Admin-Vorschlag-Detailseite warf 500er:** `templates/admin/suggestion/show.html.twig` nutzt den `|u`-Twig-Filter, das Paket `twig/string-extra` war jedoch nicht installiert. Nachinstalliert.
 - **Admin – Koordinaten-Präzision:** Breiten- und Längengrad im Restaurant-Formular werden nicht mehr auf 3 Nachkommastellen gerundet angezeigt (z. B. `5.94700000` → `5,947`), sondern mit voller Präzision von 8 Nachkommastellen – passend zu den DB-Spalten `DECIMAL(10,8)`/`DECIMAL(11,8)`. Ursache war der fehlende `scale`-Wert auf den `NumberType`-Feldern (`RestaurantType`); Default des `\NumberFormatter` sind 3 Nachkommastellen. Schützt auch beim Speichern vor Präzisionsverlust.
 
 - **Map:** Kartenansicht der Locations. *(geplant)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,26 @@ php bin/console make:migration      # Generate migration from entity diff
 ## Testing
 
 ```bash
-php bin/phpunit                     # Run all tests
-php bin/phpunit tests/              # Run specific directory
+make test                           # Test-DB vorbereiten (create/migrate/fixtures) + PHPUnit
+make test-db-setup                  # Nur Test-DB aufsetzen (einmalig nötig)
+php bin/phpunit                     # Alle Tests (Test-DB muss bereits aufgesetzt sein)
+php bin/phpunit tests/Service       # Einzelnes Verzeichnis
+php bin/phpunit --display-all-issues  # Volle Notice-/Deprecation-Texte
+composer test                       # Äquivalent zu `make test` (CI-tauglich)
 ```
 
-PHPUnit is configured in `phpunit.dist.xml` with strict mode: fails on deprecation, notices, and warnings. Bootstrap loads `.env.test` variables.
+PHPUnit is configured in `phpunit.dist.xml` with strict mode: fails on deprecation, notices, and warnings. Bootstrap loads `.env.test` variables. Läuft real auf PHP 8.5; Zielversion ist 8.4+.
 
-First test: `tests/Service/OpeningHoursServiceTest.php` (reiner Unit-Test ohne Kernel/DB). When writing tests, use `App\Tests\` namespace (PSR-4 mapped to `tests/`).
+**Test-Isolation:** `dama/doctrine-test-bundle` (in `config/bundles.php` nur `test`, Extension in `phpunit.dist.xml`) wickelt jeden Test in eine Transaktion mit Rollback. Fixtures werden **einmal vor** der Suite geladen (`make test-db-setup`), nicht in `setUp()`. Tests dürfen frei persistieren/flushen, ohne den Fixture-Stand zu verändern → wiederholbare, reihenfolgeunabhängige Läufe.
+
+**Mailer im Test:** `config/packages/messenger.yaml` (`when@test`) routet `SendEmailMessage` auf `sync` (+ `MAILER_DSN=null://null` in `.env.test`), damit `MailerAssertionsTrait` (`assertEmailCount`, `getMailerMessage`) greift.
+
+**Drei Test-Kategorien** (PSR-4-Namespace `App\Tests\`, gespiegelt unter `tests/`):
+- **Unit** (`extends TestCase`, keine DB): Services mit mockbaren Deps (`PublicTransportService` via `MockHttpClient`), Transformer (`RestaurantTransformer`/`UserTransformer` – echter `AssetUrlBuilder` mit Base-URL, da `final`), Enums, Twig-Extension, `OpeningHoursService`.
+- **KernelTestCase** (Container + DB, DAMA-isoliert): Repositories (v. a. `RestaurantRepositoryTest` – alle `findPaginated`-Filter), `ImageUploadService`/`AvatarUploadService` (Temp-Dir-Isolation via `sys_get_temp_dir`).
+- **WebTestCase** (HTTP/Forms/Auth): Web- und Admin-Controller + `/api/v1`. Basisklasse `tests/AbstractWebTestCase.php` mit `loginAs()`, `formWithField()`, `formByAction()`, `csrfTokenFrom()`. Web-Routen tragen den Locale-Prefix → `self::LOCALE` (`/de`) vor jeden Pfad.
+
+**PHPUnit-12-Konventionen (strict):** `#[DataProvider]`-Attribut statt Docblock-`@dataProvider`; `createStub()` für reine Rückgabe-Doubles, `createMock()` nur mit `expects()` (sonst Notice). Ungültige Formular-Submits liefern HTTP **422**, gültige einen 302-Redirect. Formular-CSRF ist stateless (`token_id: submit`) und passt im headless-Test via Same-Origin-Referer; Custom-Token-IDs (z. B. `toggle-verified-…`) sind session-basiert und werden als gerenderte Hidden-Felder mitgesendet.
 
 ## Architecture & Conventions
 
@@ -399,7 +412,11 @@ The project uses **CalVer** (Calendar Versioning): `vYYYY.MM.DD` (e.g., `v2026.0
 
 ## CI/CD
 
-No GitHub Actions workflows are configured yet. The `.github/` directory contains issue templates only (bug reports, feature requests, tasks).
+GitHub-Actions-Workflow `.github/workflows/ci.yml` (Trigger: Push auf `dev`/`main` + alle Pull Requests):
+- **Job `tests`** – PHP 8.4 (`shivammathur/setup-php`, Extensions inkl. `pdo_mysql`, `gd`, `intl`), MySQL-8.0-Service, Composer-Install (gecacht), JWT-Keypair (`lexik:jwt:generate-keypair --env=test --skip-if-exists`, Passphrase `changeme`), Test-DB (create/migrate/fixtures), dann `php bin/phpunit`.
+- **Job `frontend`** – Node 20, `npm ci`, `npm run typecheck` (`tsc --noEmit`), `npm run lint` (ESLint).
+
+Das `.github/`-Verzeichnis enthält außerdem Issue-Templates (Bug Reports, Feature Requests, Tasks).
 
 ## Key Files Reference
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init start stop restart db migration fixtures db-reset cc assets fix lint
+.PHONY: help init start stop restart db migration fixtures db-reset cc assets fix lint test test-db-setup
 
 # Standard-Hilfe: Zeigt alle Befehle an, wenn du nur "make" tippst
 help: ## Zeigt diese Hilfe an
@@ -49,6 +49,16 @@ db-reset: ## ⚠️ ACHTUNG: Löscht DB, migriert neu & lädt Fixtures (Alles fr
 	php bin/console doctrine:database:create
 	php bin/console doctrine:migrations:migrate --no-interaction
 	php bin/console doctrine:fixtures:load --no-interaction
+
+# --- 🧪 Tests ---
+
+test-db-setup: ## Test-Datenbank anlegen, migrieren & Fixtures laden
+	php bin/console doctrine:database:create --env=test --if-not-exists
+	php bin/console doctrine:migrations:migrate --env=test --no-interaction
+	php bin/console doctrine:fixtures:load --env=test --no-interaction
+
+test: test-db-setup ## Bereitet die Test-DB vor und führt PHPUnit aus
+	php bin/phpunit
 
 # --- 🧹 Tools & Assets ---
 

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "symfony/yaml": "8.0.*",
         "symfonycasts/tailwind-bundle": "^0.12.0",
         "twig/extra-bundle": "^2.12|^3.0",
+        "twig/string-extra": "^3.24",
         "twig/twig": "^2.12|^3.0"
     },
     "config": {
@@ -93,6 +94,12 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
+        ],
+        "test": [
+            "php bin/console doctrine:database:create --env=test --if-not-exists -q",
+            "php bin/console doctrine:migrations:migrate --env=test -n -q",
+            "php bin/console doctrine:fixtures:load --env=test -n -q",
+            "php bin/phpunit"
         ]
     },
     "conflict": {
@@ -105,6 +112,7 @@
         }
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "doctrine/doctrine-fixtures-bundle": "*",
         "phpunit/phpunit": "^12.5",
         "symfony/browser-kit": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38a353d7659c9d95afe5e99b36e7cb6e",
+    "content-hash": "fddabe5ad9307839e0fca2f5f6f560cf",
     "packages": [
         {
             "name": "composer/semver",
@@ -8200,6 +8200,73 @@
             "time": "2025-12-05T08:51:53+00:00"
         },
         {
+            "name": "twig/string-extra",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/string-extra.git",
+                "reference": "6ec8f2e8ca9b2193221a02cb599dc92c36384368"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/string-extra/zipball/6ec8f2e8ca9b2193221a02cb599dc92c36384368",
+                "reference": "6ec8f2e8ca9b2193221a02cb599dc92c36384368",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/string": "^5.4|^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^1.1|^2|^3",
+                "twig/twig": "^3.13|^4.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Symfony String",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "html",
+                "string",
+                "twig",
+                "unicode"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/string-extra/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-02T14:45:16+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v3.22.2",
             "source": {
@@ -8432,6 +8499,75 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
+        },
         {
             "name": "doctrine/data-fixtures",
             "version": "2.2.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -19,4 +19,5 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -20,6 +20,10 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+        dql:
+            # MySQL-JSON_CONTAINS für den ?lang_…-Filter (findPaginated).
+            string_functions:
+                JSON_CONTAINS: App\Doctrine\JsonContainsFunction
         controller_resolver:
             auto_mapping: false
 

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -31,7 +31,11 @@ framework:
 when@test:
     framework:
         messenger:
-            # In-Memory statt async-Doctrine: kein messenger_messages-Table nötig,
-            # E-Mails werden im Test nicht real versendet.
+            # In-Memory statt async-Doctrine: kein messenger_messages-Table nötig.
             transports:
                 async: 'in-memory://'
+                sync: 'sync://'
+            # E-Mails synchron verarbeiten, damit sie im MailerDataCollector landen
+            # und assertEmailCount()/getMailerMessage() in WebTestCase-Tests greifen.
+            routing:
+                Symfony\Component\Mailer\Messenger\SendEmailMessage: sync

--- a/config/reference.php
+++ b/config/reference.php
@@ -958,7 +958,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: false
  *     },
  *     string?: bool|array{
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     commonmark?: array{
  *         renderer?: array{ // Array of options for rendering HTML.
@@ -1644,6 +1644,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1722,6 +1728,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *         nelmio_cors?: NelmioCorsConfig,
  *         nelmio_api_doc?: NelmioApiDocConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,9 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     app.version: '2026.06.19'
-    app.mobiliteit_api_key: '%env(default::MOBILITEIT_API_KEY)%'
+    # string:-Cast, damit ein leerer/fehlender Key zu '' (nicht null) wird – sonst
+    # bricht PublicTransportService (string $apiKey) bei der Graceful-Degradation.
+    app.mobiliteit_api_key: '%env(string:default::MOBILITEIT_API_KEY)%'
     app.mobiliteit_radius: 500
     app.mobiliteit_max_stops: 5
 

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -40,5 +40,6 @@
     </source>
 
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
 </phpunit>

--- a/src/Doctrine/JsonContainsFunction.php
+++ b/src/Doctrine/JsonContainsFunction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+
+/**
+ * "JSON_CONTAINS" "(" StringPrimary "," StringPrimary ["," StringPrimary] ")"
+ *
+ * Bildet die MySQL-Funktion JSON_CONTAINS(target, candidate[, path]) in DQL ab.
+ * Doctrine ORM kennt sie nicht von Haus aus – ohne diese Registrierung wirft
+ * der `?lang_…`-Filter (RestaurantRepository::findPaginated) eine QueryException.
+ */
+final class JsonContainsFunction extends FunctionNode
+{
+    private Node $target;
+    private Node $candidate;
+    private ?Node $path = null;
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+
+        $this->target = $parser->StringPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->candidate = $parser->StringPrimary();
+
+        if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
+            $this->path = $parser->StringPrimary();
+        }
+
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        $sql = 'JSON_CONTAINS('
+            .$sqlWalker->walkStringPrimary($this->target).', '
+            .$sqlWalker->walkStringPrimary($this->candidate);
+
+        if ($this->path !== null) {
+            $sql .= ', '.$sqlWalker->walkStringPrimary($this->path);
+        }
+
+        return $sql.')';
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,13 @@
 {
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        }
+    },
     "doctrine/deprecations": {
         "version": "1.1",
         "recipe": {

--- a/tests/AbstractWebTestCase.php
+++ b/tests/AbstractWebTestCase.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Form;
+
+/**
+ * Basisklasse für funktionale Web-Tests.
+ *
+ * Web-Routen tragen den Locale-Prefix (config/routes.yaml) – daher self::LOCALE
+ * vor jeden Pfad setzen. DAMADoctrineTestBundle isoliert jeden Test per Transaktion.
+ */
+abstract class AbstractWebTestCase extends WebTestCase
+{
+    protected const LOCALE = '/de';
+
+    protected function user(KernelBrowser $client, string $email): User
+    {
+        $user = $client->getContainer()->get(UserRepository::class)->findOneBy(['email' => $email]);
+        self::assertNotNull($user, "Fixture-User {$email} fehlt – Test-DB nicht geladen?");
+
+        return $user;
+    }
+
+    protected function loginAs(KernelBrowser $client, string $email): User
+    {
+        $user = $this->user($client, $email);
+        $client->loginUser($user);
+
+        return $user;
+    }
+
+    /**
+     * Liest den (session-basierten) CSRF-Token-Wert eines Hidden-Felds oder
+     * data-Attributs aus der zuletzt gerenderten Seite – nötig für die Custom-Token-IDs
+     * (toggle-verified-…, sort-images-… usw.), die NICHT stateless sind.
+     */
+    protected function csrfTokenFrom(Crawler $crawler, string $cssSelector, string $attribute = 'value'): string
+    {
+        $node = $crawler->filter($cssSelector);
+        self::assertGreaterThan(0, $node->count(), "CSRF-Token-Knoten nicht gefunden: {$cssSelector}");
+
+        return (string) $node->attr($attribute);
+    }
+
+    /**
+     * Liefert das erste Formular der Seite, das ein Feld mit dem gegebenen name-Attribut
+     * enthält (robust gegenüber zusätzlichen Formularen wie Logout/Nav). Das gerenderte
+     * _token wird vom Form-Objekt automatisch übernommen.
+     *
+     * @param array<string, string> $values
+     */
+    protected function formWithField(Crawler $crawler, string $fieldName, array $values = []): Form
+    {
+        $forms = $crawler->filter('form');
+        for ($i = 0; $i < $forms->count(); ++$i) {
+            $form = $forms->eq($i);
+            if ($form->filter('[name="'.$fieldName.'"]')->count() > 0) {
+                return $form->form($values);
+            }
+        }
+
+        self::fail("Kein Formular mit Feld {$fieldName} gefunden.");
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    protected function formByAction(Crawler $crawler, string $actionSuffix, array $values = []): Form
+    {
+        $node = $crawler->filter('form[action$="'.$actionSuffix.'"]');
+        self::assertGreaterThan(0, $node->count(), "Kein Formular mit action {$actionSuffix}.");
+
+        return $node->first()->form($values);
+    }
+}

--- a/tests/Api/RestaurantTransformerTest.php
+++ b/tests/Api/RestaurantTransformerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace App\Tests\Api;
+
+use App\Api\AssetUrlBuilder;
+use App\Api\RestaurantTransformer;
+use App\Entity\Cuisine;
+use App\Entity\OpeningHour;
+use App\Entity\OrderingOption;
+use App\Entity\Restaurant;
+use App\Entity\RestaurantImage;
+use App\Entity\User;
+use App\Enum\Language;
+use App\Enum\OrderingPlatform;
+use App\Service\OpeningHoursService;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class RestaurantTransformerTest extends TestCase
+{
+    private OpeningHoursService&Stub $openingHours;
+
+    protected function setUp(): void
+    {
+        // Reiner Stub (nur Rückgabewerte, keine Verhaltens-Erwartungen).
+        $this->openingHours = $this->createStub(OpeningHoursService::class);
+    }
+
+    private function transformer(): RestaurantTransformer
+    {
+        return new RestaurantTransformer(
+            $this->openingHours,
+            new AssetUrlBuilder(new RequestStack(), 'https://cdn.test'),
+        );
+    }
+
+    private function slot(int $day, string $open, string $close): OpeningHour
+    {
+        return (new OpeningHour())
+            ->setDayOfWeek($day)
+            ->setOpenTime(new \DateTime($open))
+            ->setCloseTime(new \DateTime($close));
+    }
+
+    private function fullRestaurant(): Restaurant
+    {
+        $restaurant = (new Restaurant())
+            ->setName('Pizzeria Bella Vista')
+            ->setCity('Strassen')
+            ->setEmoji('🍕')
+            ->setRating(8.5)
+            ->setIsVerified(true)
+            ->setIsWheelchairAccessible(true)
+            ->setHasAccessibleToilet(true)
+            ->setAllowsAssistanceDogs(false)
+            ->setHasBrightLighting(true)
+            ->setHasChangingTable(false)
+            ->setHasDisabledParking(true)
+            ->setAcceptsCash(true)
+            ->setAcceptsCard(true)
+            ->setAcceptsPayconiq(false)
+            ->setIsVegan(false)
+            ->setIsVegetarian(true)
+            ->setIsHalal(false)
+            ->setPhone('+352 12 34 56')
+            ->setEmail('info@bella.lu')
+            ->setWebsite('https://bella.lu')
+            ->setInstagramUrl('https://instagram.com/bella')
+            ->setLatitude('49.61160000')
+            ->setLongitude('6.13190000')
+            ->setNearbyStopsNote('2 Min. zur Tram')
+            ->setAccessibilityNotes(['ok:Eingang stufenlos'])
+            ->setSpokenLanguages([Language::DE, Language::FR]);
+
+        $restaurant->addCuisine((new Cuisine())->setName('Pizza')->setSlug('pizza'));
+
+        $restaurant->addOpeningHour($this->slot(3, '12:00', '14:30'));
+        $restaurant->addOpeningHour($this->slot(3, '18:00', '22:00'));
+
+        $restaurant->addOrderingOption(
+            (new OrderingOption())->setPlatform(OrderingPlatform::UBER_EATS)->setUrl('https://ubereats.com/bella')
+        );
+
+        $restaurant->getImages()->add(
+            (new RestaurantImage())->setFilename('cover.jpg')->setAltText('Cover')->setSortOrder(0)
+        );
+
+        $restaurant->setSubmittedBy((new User())->setName('Alice')->setEmail('alice@endlech.lu'));
+
+        return $restaurant;
+    }
+
+    public function testListMapsCompactFields(): void
+    {
+        $this->openingHours->method('isOpenNow')->willReturn(true);
+
+        $data = $this->transformer()->list($this->fullRestaurant());
+
+        self::assertSame('Pizzeria Bella Vista', $data['name']);
+        self::assertSame('Strassen', $data['city']);
+        self::assertSame('🍕', $data['emoji']);
+        self::assertSame(8.5, $data['rating']);
+        self::assertTrue($data['isVerified']);
+        self::assertTrue($data['isOpenNow']);
+        self::assertSame('https://cdn.test/uploads/restaurants/cover.jpg', $data['coverImageUrl']);
+        self::assertSame([['id' => null, 'name' => 'Pizza', 'slug' => 'pizza']], $data['cuisines']);
+        self::assertSame([
+            'wheelchairAccessible' => true,
+            'accessibleToilet' => true,
+            'assistanceDogs' => false,
+            'brightLighting' => true,
+            'changingTable' => false,
+            'disabledParking' => true,
+        ], $data['accessibility']);
+        self::assertSame(['vegan' => false, 'vegetarian' => true, 'halal' => false], $data['dietary']);
+        self::assertNotEmpty($data['createdAt']);
+    }
+
+    public function testCoverImageUrlIsNullWithoutImages(): void
+    {
+        $this->openingHours->method('isOpenNow')->willReturn(false);
+
+        $data = $this->transformer()->list(new Restaurant());
+
+        self::assertNull($data['coverImageUrl']);
+        self::assertSame([], $data['cuisines']);
+    }
+
+    public function testDetailMapsNestedStructures(): void
+    {
+        $this->openingHours->method('isOpenNow')->willReturn(true);
+        $this->openingHours->method('getNextOpeningTime')->willReturn([
+            'dayOfWeek' => 3,
+            'time' => new \DateTime('18:00'),
+        ]);
+
+        $data = $this->transformer()->detail($this->fullRestaurant());
+
+        self::assertSame(['cash' => true, 'card' => true, 'payconiq' => false], $data['payment']);
+
+        self::assertSame('+352 12 34 56', $data['contact']['phone']);
+        self::assertSame('info@bella.lu', $data['contact']['email']);
+        self::assertSame('https://instagram.com/bella', $data['contact']['instagramUrl']);
+
+        self::assertSame('49.61160000', $data['location']['latitude']);
+        self::assertSame('6.13190000', $data['location']['longitude']);
+        self::assertSame('2 Min. zur Tram', $data['location']['nearbyStopsNote']);
+
+        self::assertSame(['ok:Eingang stufenlos'], $data['accessibilityNotes']);
+
+        self::assertCount(2, $data['spokenLanguages']);
+        self::assertSame(['code' => 'de', 'label' => 'Deutsch', 'flag' => '🇩🇪'], $data['spokenLanguages'][0]);
+
+        // Öffnungszeiten: 7 Tage, Tag 3 hat zwei Slots, restliche Tage leer.
+        self::assertCount(7, $data['openingHours']);
+        self::assertSame(3, $data['openingHours'][2]['dayOfWeek']);
+        self::assertSame([
+            ['open' => '12:00', 'close' => '14:30'],
+            ['open' => '18:00', 'close' => '22:00'],
+        ], $data['openingHours'][2]['slots']);
+        self::assertSame([], $data['openingHours'][0]['slots']);
+
+        self::assertSame(['dayOfWeek' => 3, 'time' => '18:00'], $data['nextOpeningTime']);
+
+        self::assertCount(1, $data['orderingOptions']);
+        self::assertSame('uber_eats', $data['orderingOptions'][0]['platform']);
+        self::assertSame('Uber Eats', $data['orderingOptions'][0]['label']);
+        self::assertSame('images/platforms/uber-eats.svg', $data['orderingOptions'][0]['logoPath']);
+
+        self::assertCount(1, $data['images']);
+        self::assertSame('https://cdn.test/uploads/restaurants/cover.jpg', $data['images'][0]['url']);
+        self::assertSame('Cover', $data['images'][0]['altText']);
+
+        self::assertSame('Alice', $data['submittedBy']['name']);
+    }
+
+    public function testDetailNextOpeningTimeNullWhenServiceReturnsNull(): void
+    {
+        $this->openingHours->method('isOpenNow')->willReturn(false);
+        $this->openingHours->method('getNextOpeningTime')->willReturn(null);
+
+        $data = $this->transformer()->detail(new Restaurant());
+
+        self::assertNull($data['nextOpeningTime']);
+        self::assertNull($data['submittedBy']);
+    }
+
+    public function testImageMapsToAbsoluteUrl(): void
+    {
+        $image = (new RestaurantImage())->setFilename('photo-1.jpg')->setAltText('Innen')->setSortOrder(2);
+
+        $data = $this->transformer()->image($image);
+
+        self::assertSame('https://cdn.test/uploads/restaurants/photo-1.jpg', $data['url']);
+        self::assertSame('Innen', $data['altText']);
+        self::assertSame(2, $data['sortOrder']);
+    }
+}

--- a/tests/Api/UserTransformerTest.php
+++ b/tests/Api/UserTransformerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Api;
+
+use App\Api\AssetUrlBuilder;
+use App\Api\UserTransformer;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class UserTransformerTest extends TestCase
+{
+    private function transformer(): UserTransformer
+    {
+        // Echter AssetUrlBuilder (final) mit fixem Base-URL-Override statt Request-Kontext.
+        return new UserTransformer(new AssetUrlBuilder(new RequestStack(), 'https://cdn.test'));
+    }
+
+    public function testProfileExposesExpectedFields(): void
+    {
+        $user = (new User())
+            ->setName('Alice')
+            ->setEmail('alice@endlech.lu')
+            ->setRoles(['ROLE_ADMIN'])
+            ->setIsVerified(true)
+            ->setAvatarFilename('alice.png');
+
+        $data = $this->transformer()->profile($user);
+
+        self::assertSame('Alice', $data['name']);
+        self::assertSame('alice@endlech.lu', $data['email']);
+        self::assertSame('https://cdn.test/uploads/avatars/alice.png', $data['avatarUrl']);
+        self::assertTrue($data['isVerified']);
+        self::assertContains('ROLE_ADMIN', $data['roles']);
+        self::assertContains('ROLE_USER', $data['roles']);
+        self::assertNotEmpty($data['createdAt']);
+    }
+
+    public function testProfileNeverLeaksSensitiveFields(): void
+    {
+        $user = (new User())
+            ->setName('Bob')
+            ->setEmail('bob@endlech.lu')
+            ->setPassword('hashed-secret');
+        $user->generateVerificationToken();
+
+        $data = $this->transformer()->profile($user);
+
+        self::assertArrayNotHasKey('password', $data);
+        self::assertArrayNotHasKey('verificationToken', $data);
+        self::assertSame('hashed-secret', $user->getPassword(), 'Sanity-Check: Passwort am User gesetzt.');
+        self::assertNotContains('hashed-secret', $data, 'Passwort darf nicht im Profil auftauchen.');
+    }
+
+    public function testProfileWithoutAvatarReturnsNullUrl(): void
+    {
+        $user = (new User())->setName('Carol')->setEmail('carol@endlech.lu');
+
+        $data = $this->transformer()->profile($user);
+
+        self::assertNull($data['avatarUrl']);
+    }
+}

--- a/tests/Controller/AdminDashboardControllerTest.php
+++ b/tests/Controller/AdminDashboardControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\AbstractWebTestCase;
+
+final class AdminDashboardControllerTest extends AbstractWebTestCase
+{
+    public function testAnonymousIsRedirectedToLogin(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/admin');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testNonAdminIsForbidden(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/admin');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminSeesDashboard(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/admin');
+
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Controller/AdminRestaurantControllerTest.php
+++ b/tests/Controller/AdminRestaurantControllerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\Restaurant;
+use App\Entity\RestaurantImage;
+use App\Repository\RestaurantRepository;
+use App\Tests\AbstractWebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AdminRestaurantControllerTest extends AbstractWebTestCase
+{
+    private function em(object $client): EntityManagerInterface
+    {
+        return $client->getContainer()->get(EntityManagerInterface::class);
+    }
+
+    private function restaurants(object $client): RestaurantRepository
+    {
+        return $client->getContainer()->get(RestaurantRepository::class);
+    }
+
+    private function createRestaurant(object $client, string $name): Restaurant
+    {
+        $restaurant = (new Restaurant())->setName($name)->setCity('Luxembourg');
+        $em = $this->em($client);
+        $em->persist($restaurant);
+        $em->flush();
+
+        return $restaurant;
+    }
+
+    private function createImage(object $client, Restaurant $restaurant, int $sortOrder): RestaurantImage
+    {
+        $image = (new RestaurantImage())->setFilename('fake-'.$sortOrder.'.jpg')->setSortOrder($sortOrder);
+        $image->setRestaurant($restaurant);
+        $em = $this->em($client);
+        $em->persist($image);
+        $em->flush();
+
+        return $image;
+    }
+
+    public function testIndexForbiddenForNonAdmin(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+        $client->request('GET', self::LOCALE.'/admin/restaurants');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testIndexLoadsForAdmin(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+        $client->request('GET', self::LOCALE.'/admin/restaurants');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testNewFormLoads(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+        $client->request('GET', self::LOCALE.'/admin/restaurants/neu');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testCreateRestaurant(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $name = 'Admin Neu '.uniqid();
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants/neu');
+        $client->submit($this->formWithField($crawler, 'restaurant[name]', [
+            'restaurant[name]' => $name,
+            'restaurant[city]' => 'Diekirch',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/restaurants');
+        self::assertNotNull($this->restaurants($client)->findOneBy(['name' => $name]));
+    }
+
+    public function testEditTogglesVerification(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $restaurant = $this->createRestaurant($client, 'Edit Verify '.uniqid());
+        $id = $restaurant->getId();
+
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants/'.$id.'/bearbeiten');
+        $form = $this->formWithField($crawler, 'restaurant[name]');
+        $form['restaurant[isVerified]']->tick();
+        $client->submit($form);
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/restaurants');
+
+        $this->em($client)->clear();
+        $reloaded = $this->restaurants($client)->find($id);
+        self::assertTrue($reloaded->isVerified());
+        self::assertNotNull($reloaded->getVerifiedAt());
+        self::assertNotNull($reloaded->getVerifiedBy());
+    }
+
+    public function testToggleVerifiedWithValidCsrf(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $restaurant = $this->createRestaurant($client, 'Toggle '.uniqid());
+        $id = $restaurant->getId();
+        $wasVerified = $restaurant->isVerified();
+
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants');
+        $client->submit($this->formByAction($crawler, '/'.$id.'/verifizieren'));
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/restaurants');
+
+        $this->em($client)->clear();
+        self::assertNotSame($wasVerified, $this->restaurants($client)->find($id)->isVerified());
+    }
+
+    public function testToggleVerifiedWithInvalidCsrfDoesNotChange(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $restaurant = $this->createRestaurant($client, 'Toggle Invalid '.uniqid());
+        $id = $restaurant->getId();
+
+        $client->request('POST', self::LOCALE.'/admin/restaurants/'.$id.'/verifizieren', ['_token' => 'ungueltig']);
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/restaurants');
+        $this->em($client)->clear();
+        self::assertFalse($this->restaurants($client)->find($id)->isVerified());
+    }
+
+    public function testDeleteImage(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $restaurant = $this->createRestaurant($client, 'Bild Lösch '.uniqid());
+        $image = $this->createImage($client, $restaurant, 1);
+        $imageId = $image->getId();
+        $restaurantId = $restaurant->getId();
+
+        // EM leeren, damit der Request das Restaurant samt Bildern frisch aus der DB lädt.
+        $this->em($client)->clear();
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants/'.$restaurantId.'/bearbeiten');
+        $client->submit($this->formByAction($crawler, '/fotos/'.$imageId.'/loeschen'));
+
+        self::assertResponseRedirects();
+        self::assertNull($client->getContainer()->get('doctrine')->getManager()->getRepository(RestaurantImage::class)->find($imageId));
+    }
+
+    public function testSortImagesWithInvalidCsrfReturns403(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+        $restaurant = $this->createRestaurant($client, 'Sort CSRF '.uniqid());
+
+        $client->request(
+            'POST',
+            self::LOCALE.'/admin/restaurants/'.$restaurant->getId().'/fotos/sortieren',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['_token' => 'ungueltig', 'imageIds' => []]),
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testSortImagesReordersWithValidToken(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $restaurant = $this->createRestaurant($client, 'Sort OK '.uniqid());
+        $first = $this->createImage($client, $restaurant, 0);
+        $second = $this->createImage($client, $restaurant, 1);
+        $restaurantId = $restaurant->getId();
+
+        $this->em($client)->clear();
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants/'.$restaurantId.'/bearbeiten');
+        $token = $this->csrfTokenFrom($crawler, '[data-image-sort-token-value]', 'data-image-sort-token-value');
+
+        // Reihenfolge umkehren: second -> sortOrder 0, first -> sortOrder 1.
+        $client->request(
+            'POST',
+            self::LOCALE.'/admin/restaurants/'.$restaurant->getId().'/fotos/sortieren',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['_token' => $token, 'imageIds' => [$second->getId(), $first->getId()]]),
+        );
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonStringEqualsJsonString('{"success":true}', $client->getResponse()->getContent());
+
+        $repo = $client->getContainer()->get('doctrine')->getManager()->getRepository(RestaurantImage::class);
+        self::assertSame(1, $repo->find($first->getId())->getSortOrder());
+        self::assertSame(0, $repo->find($second->getId())->getSortOrder());
+    }
+
+    public function testSortImagesRejectsForeignImageWith400(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $owner = $this->createRestaurant($client, 'Eigner '.uniqid());
+        // Eigenes Bild, damit der Sortier-Container (inkl. Token) überhaupt gerendert wird.
+        $this->createImage($client, $owner, 0);
+        $foreignImage = $this->createImage($client, $this->createRestaurant($client, 'Fremd '.uniqid()), 0);
+        $ownerId = $owner->getId();
+        $foreignImageId = $foreignImage->getId();
+
+        $this->em($client)->clear();
+        $crawler = $client->request('GET', self::LOCALE.'/admin/restaurants/'.$ownerId.'/bearbeiten');
+        $token = $this->csrfTokenFrom($crawler, '[data-image-sort-token-value]', 'data-image-sort-token-value');
+
+        $client->request(
+            'POST',
+            self::LOCALE.'/admin/restaurants/'.$ownerId.'/fotos/sortieren',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['_token' => $token, 'imageIds' => [$foreignImageId]]),
+        );
+
+        self::assertResponseStatusCodeSame(400);
+    }
+}

--- a/tests/Controller/AdminSuggestionControllerTest.php
+++ b/tests/Controller/AdminSuggestionControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\RestaurantSuggestion;
+use App\Repository\RestaurantRepository;
+use App\Repository\RestaurantSuggestionRepository;
+use App\Repository\UserRepository;
+use App\Tests\AbstractWebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AdminSuggestionControllerTest extends AbstractWebTestCase
+{
+    private function createSuggestion(object $client, string $name): RestaurantSuggestion
+    {
+        $user = $client->getContainer()->get(UserRepository::class)->findOneBy(['email' => 'user@endlech.lu']);
+        $suggestion = (new RestaurantSuggestion())
+            ->setName($name)
+            ->setCity('Wiltz')
+            ->setCuisine('Italienisch, Pizza')
+            ->setSuggestedBy($user);
+
+        $em = $client->getContainer()->get(EntityManagerInterface::class);
+        $em->persist($suggestion);
+        $em->flush();
+
+        return $suggestion;
+    }
+
+    private function suggestions(object $client): RestaurantSuggestionRepository
+    {
+        return $client->getContainer()->get(RestaurantSuggestionRepository::class);
+    }
+
+    public function testIndexForbiddenForNonAdmin(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+        $client->request('GET', self::LOCALE.'/admin/vorschlaege');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testApproveCreatesRestaurantAndMarksApproved(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $name = 'Vorschlag Genehmigt '.uniqid();
+        $suggestion = $this->createSuggestion($client, $name);
+        $id = $suggestion->getId();
+
+        $crawler = $client->request('GET', self::LOCALE.'/admin/vorschlaege/'.$id);
+        $client->submit($this->formByAction($crawler, '/'.$id.'/genehmigen'));
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/vorschlaege');
+
+        $client->getContainer()->get(EntityManagerInterface::class)->clear();
+        $restaurant = $client->getContainer()->get(RestaurantRepository::class)->findOneBy(['name' => $name]);
+        self::assertNotNull($restaurant, 'Aus dem Vorschlag muss ein Restaurant entstehen.');
+        self::assertGreaterThanOrEqual(1, $restaurant->getCuisines()->count());
+
+        self::assertSame(RestaurantSuggestion::STATUS_APPROVED, $this->suggestions($client)->find($id)->getStatus());
+    }
+
+    public function testRejectMarksRejectedWithNote(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $suggestion = $this->createSuggestion($client, 'Vorschlag Abgelehnt '.uniqid());
+        $id = $suggestion->getId();
+
+        $crawler = $client->request('GET', self::LOCALE.'/admin/vorschlaege/'.$id);
+        $client->submit($this->formByAction($crawler, '/'.$id.'/ablehnen', [
+            'admin_note' => 'Leider nicht barrierefrei.',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/vorschlaege');
+
+        $client->getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloaded = $this->suggestions($client)->find($id);
+        self::assertSame(RestaurantSuggestion::STATUS_REJECTED, $reloaded->getStatus());
+        self::assertSame('Leider nicht barrierefrei.', $reloaded->getAdminNote());
+    }
+
+    public function testApproveWithInvalidCsrfKeepsPending(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'admin@endlech.lu');
+
+        $suggestion = $this->createSuggestion($client, 'Vorschlag CSRF '.uniqid());
+        $id = $suggestion->getId();
+
+        $client->request('POST', self::LOCALE.'/admin/vorschlaege/'.$id.'/genehmigen', ['_token' => 'ungueltig']);
+
+        self::assertResponseRedirects(self::LOCALE.'/admin/vorschlaege');
+        $client->getContainer()->get(EntityManagerInterface::class)->clear();
+        self::assertSame(RestaurantSuggestion::STATUS_PENDING, $this->suggestions($client)->find($id)->getStatus());
+    }
+}

--- a/tests/Controller/Api/V1/RestaurantApiControllerTest.php
+++ b/tests/Controller/Api/V1/RestaurantApiControllerTest.php
@@ -141,6 +141,52 @@ final class RestaurantApiControllerTest extends WebTestCase
         self::assertEqualsWithDelta(6.1319, (float) $data['location']['longitude'], 0.0000001);
     }
 
+    public function testCreateMarksSubmitterAndIsUnverified(): void
+    {
+        $client = static::createClient();
+        $userId = static::getContainer()->get(UserRepository::class)->findOneBy(['email' => 'user@endlech.lu'])->getId();
+
+        $client->request(
+            'POST',
+            '/api/v1/restaurants',
+            server: ['CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer ' . $this->token()],
+            content: json_encode(['name' => 'Eingereicht API ' . uniqid(), 'city' => 'Luxembourg']),
+        );
+
+        self::assertResponseStatusCodeSame(201);
+        $data = $this->json($client);
+        self::assertFalse($data['isVerified']);
+        self::assertNotNull($data['submittedBy']);
+        self::assertSame($userId, $data['submittedBy']['id']);
+    }
+
+    public function testCreateRejectsMissingNameWith422(): void
+    {
+        $client = static::createClient();
+        $client->request(
+            'POST',
+            '/api/v1/restaurants',
+            server: ['CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer ' . $this->token()],
+            content: json_encode(['city' => 'Luxembourg']),
+        );
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertArrayHasKey('name', $this->json($client)['error']['violations']);
+    }
+
+    public function testCreateRejectsInvalidJsonWith400(): void
+    {
+        $client = static::createClient();
+        $client->request(
+            'POST',
+            '/api/v1/restaurants',
+            server: ['CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer ' . $this->token()],
+            content: '"kein-objekt"',
+        );
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Controller/CommunityControllerTest.php
+++ b/tests/Controller/CommunityControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Repository\RestaurantSuggestionRepository;
+use App\Tests\AbstractWebTestCase;
+
+final class CommunityControllerTest extends AbstractWebTestCase
+{
+    public function testGuestIsRedirectedToLogin(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/community/suggest');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testUnverifiedUserIsRedirected(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'unverified@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/community/suggest');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testVerifiedUserSeesForm(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/community/suggest');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testVerifiedUserCanSubmitSuggestion(): void
+    {
+        $client = static::createClient();
+        $user = $this->loginAs($client, 'user@endlech.lu');
+
+        $name = 'Vorschlag '.uniqid();
+        $crawler = $client->request('GET', self::LOCALE.'/community/suggest');
+        $client->submit($this->formWithField($crawler, 'restaurant_suggestion[name]', [
+            'restaurant_suggestion[name]' => $name,
+            'restaurant_suggestion[city]' => 'Esch-sur-Alzette',
+            'restaurant_suggestion[cuisine]' => 'Italienisch',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/community/thanks');
+
+        $suggestion = $client->getContainer()->get(RestaurantSuggestionRepository::class)->findOneBy(['name' => $name]);
+        self::assertNotNull($suggestion);
+        self::assertSame($user->getId(), $suggestion->getSuggestedBy()?->getId());
+    }
+}

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\AbstractWebTestCase;
+
+final class HomeControllerTest extends AbstractWebTestCase
+{
+    public function testHomePageLoads(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/');
+
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Repository\UserRepository;
+use App\Tests\AbstractWebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class ProfileControllerTest extends AbstractWebTestCase
+{
+    public function testProfileRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/profile');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testProfileLoadsForAuthenticatedUser(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/profile');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testChangePasswordWithWrongCurrentIsRejected(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $crawler = $client->request('GET', self::LOCALE.'/profile');
+        $client->submit($this->formWithField($crawler, 'change_password[currentPassword]', [
+            'change_password[currentPassword]' => 'falsches-passwort',
+            'change_password[newPassword][first]' => 'neuespasswort',
+            'change_password[newPassword][second]' => 'neuespasswort',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/profile');
+
+        // Passwort bleibt unverändert.
+        $container = $client->getContainer();
+        $container->get(EntityManagerInterface::class)->clear();
+        $user = $container->get(UserRepository::class)->findOneBy(['email' => 'user@endlech.lu']);
+        self::assertTrue($container->get(UserPasswordHasherInterface::class)->isPasswordValid($user, 'user123'));
+    }
+
+    public function testChangePasswordSuccess(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $crawler = $client->request('GET', self::LOCALE.'/profile');
+        $client->submit($this->formWithField($crawler, 'change_password[currentPassword]', [
+            'change_password[currentPassword]' => 'user123',
+            'change_password[newPassword][first]' => 'ganzneuespasswort',
+            'change_password[newPassword][second]' => 'ganzneuespasswort',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/profile');
+
+        $container = $client->getContainer();
+        $container->get(EntityManagerInterface::class)->clear();
+        $user = $container->get(UserRepository::class)->findOneBy(['email' => 'user@endlech.lu']);
+        self::assertTrue($container->get(UserPasswordHasherInterface::class)->isPasswordValid($user, 'ganzneuespasswort'));
+    }
+
+    public function testDeleteAvatarWithInvalidCsrfShowsError(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $client->request('POST', self::LOCALE.'/profile/avatar/delete', ['_token' => 'ungueltig']);
+
+        self::assertResponseRedirects(self::LOCALE.'/profile');
+    }
+}

--- a/tests/Controller/RegistrationControllerTest.php
+++ b/tests/Controller/RegistrationControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Repository\UserRepository;
+use App\Tests\AbstractWebTestCase;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
+
+final class RegistrationControllerTest extends AbstractWebTestCase
+{
+    public function testRegisterPageLoads(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/register');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSuccessfulRegistrationCreatesUserAndSendsEmail(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', self::LOCALE.'/register');
+
+        $email = 'neu_'.uniqid().'@endlech.lu';
+        $client->submit($this->formWithField($crawler, 'registration[email]', [
+            'registration[name]' => 'Neu Benutzer',
+            'registration[email]' => $email,
+            'registration[plainPassword][first]' => 'supersecret',
+            'registration[plainPassword][second]' => 'supersecret',
+        ]));
+
+        self::assertResponseRedirects();
+        self::assertEmailCount(1);
+        self::assertEmailAddressContains(self::getMailerMessage(), 'To', $email);
+
+        $user = $client->getContainer()->get(UserRepository::class)->findOneBy(['email' => $email]);
+        self::assertNotNull($user);
+        self::assertFalse($user->isVerified());
+        self::assertNotNull($user->getVerificationToken());
+    }
+
+    public function testValidationErrorsRerenderWithoutSendingEmail(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', self::LOCALE.'/register');
+
+        $client->submit($this->formWithField($crawler, 'registration[email]', [
+            'registration[name]' => 'X',
+            'registration[email]' => 'keine-email',
+            'registration[plainPassword][first]' => '123',
+            'registration[plainPassword][second]' => '123',
+        ]));
+
+        // Ungültiges Formular wird mit Fehlern neu gerendert (Symfony: HTTP 422).
+        self::assertResponseStatusCodeSame(422);
+        self::assertEmailCount(0);
+    }
+
+    public function testMailerFailureShowsWarningAndStillRedirects(): void
+    {
+        $client = static::createClient();
+        $client->getContainer()->set(MailerInterface::class, new class implements MailerInterface {
+            public function send(RawMessage $message, ?Envelope $envelope = null): void
+            {
+                throw new TransportException('SMTP down');
+            }
+        });
+
+        $crawler = $client->request('GET', self::LOCALE.'/register');
+        $client->submit($this->formWithField($crawler, 'registration[email]', [
+            'registration[name]' => 'Mailer Pech',
+            'registration[email]' => 'mailerfail_'.uniqid().'@endlech.lu',
+            'registration[plainPassword][first]' => 'supersecret',
+            'registration[plainPassword][second]' => 'supersecret',
+        ]));
+
+        // Trotz Mailer-Fehler kein 500er, sondern Redirect (mit Warnung).
+        self::assertResponseRedirects();
+    }
+}

--- a/tests/Controller/RestaurantControllerTest.php
+++ b/tests/Controller/RestaurantControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Repository\RestaurantRepository;
+use App\Tests\AbstractWebTestCase;
+
+final class RestaurantControllerTest extends AbstractWebTestCase
+{
+    public function testIndexLoads(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/restaurants');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testIndexWithSortAndFilters(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/restaurants?sort=name&verified=1&vegan=1&city=Lux');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * Regression: Der ?lang_…-Filter nutzt JSON_CONTAINS. Ohne die registrierte
+     * DQL-Funktion (App\Doctrine\JsonContainsFunction) warf diese Route einen 500er.
+     */
+    public function testLanguageFilterDoesNotError(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/restaurants?lang_de=1&lang_fr=1');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testInvalidSortFallsBackGracefully(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/restaurants?sort=unsinn&page=0');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testShowLoads(): void
+    {
+        $client = static::createClient();
+        $id = $client->getContainer()->get(RestaurantRepository::class)->findOneBy([])->getId();
+
+        $client->request('GET', self::LOCALE.'/restaurants/'.$id);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testShowUnknownReturns404(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOCALE.'/restaurants/99999999');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\AbstractWebTestCase;
+
+final class SecurityControllerTest extends AbstractWebTestCase
+{
+    public function testLoginPageLoads(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', self::LOCALE.'/login');
+
+        self::assertResponseIsSuccessful();
+        self::assertGreaterThan(0, $crawler->filter('input[name="_password"]')->count());
+    }
+
+    public function testLoggedInUserIsRedirected(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'user@endlech.lu');
+
+        $client->request('GET', self::LOCALE.'/login');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testValidCredentialsAuthenticate(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', self::LOCALE.'/login');
+
+        $client->submit($crawler->filter('form')->form([
+            '_username' => 'user@endlech.lu',
+            '_password' => 'user123',
+        ]));
+
+        self::assertResponseRedirects(self::LOCALE.'/');
+        $client->followRedirect();
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testInvalidCredentialsAreRejected(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', self::LOCALE.'/login');
+
+        $client->submit($crawler->filter('form')->form([
+            '_username' => 'user@endlech.lu',
+            '_password' => 'falsches-passwort',
+        ]));
+
+        // Zurück zur Login-Seite (Authentifizierung fehlgeschlagen).
+        self::assertResponseRedirects(self::LOCALE.'/login');
+    }
+}

--- a/tests/Enum/LanguageTest.php
+++ b/tests/Enum/LanguageTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Enum;
+
+use App\Enum\Language;
+use PHPUnit\Framework\TestCase;
+
+final class LanguageTest extends TestCase
+{
+    public function testEveryCaseHasLabelFlagAndTransKey(): void
+    {
+        foreach (Language::cases() as $language) {
+            self::assertNotSame('', $language->label(), $language->value.' label');
+            self::assertNotSame('', $language->flag(), $language->value.' flag');
+            self::assertSame('language.'.$language->value, $language->transKey());
+        }
+    }
+
+    public function testLabels(): void
+    {
+        self::assertSame('Lëtzebuergesch', Language::LU->label());
+        self::assertSame('Deutsch', Language::DE->label());
+        self::assertSame('Français', Language::FR->label());
+        self::assertSame('English', Language::EN->label());
+        self::assertSame('Português', Language::PT->label());
+        self::assertSame('Andere', Language::OTHER->label());
+    }
+
+    public function testFlags(): void
+    {
+        self::assertSame('🇱🇺', Language::LU->flag());
+        self::assertSame('🇬🇧', Language::EN->flag());
+        self::assertSame('🌐', Language::OTHER->flag());
+    }
+
+    public function testBadgeLabelCombinesFlagAndLabel(): void
+    {
+        self::assertSame('🇱🇺 Lëtzebuergesch', Language::LU->badgeLabel());
+        self::assertSame('🇫🇷 Français', Language::FR->badgeLabel());
+    }
+}

--- a/tests/Enum/OrderingPlatformTest.php
+++ b/tests/Enum/OrderingPlatformTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Enum;
+
+use App\Enum\OrderingPlatform;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OrderingPlatformTest extends TestCase
+{
+    public function testEveryCaseHasNonEmptyLabelAndEmoji(): void
+    {
+        foreach (OrderingPlatform::cases() as $platform) {
+            self::assertNotSame('', $platform->label(), $platform->value.' label');
+            self::assertNotSame('', $platform->emoji(), $platform->value.' emoji');
+        }
+    }
+
+    public function testLabels(): void
+    {
+        self::assertSame('Uber Eats', OrderingPlatform::UBER_EATS->label());
+        self::assertSame('Telefon', OrderingPlatform::PHONE->label());
+        self::assertSame('Andere', OrderingPlatform::OTHER->label());
+    }
+
+    public function testActionLabel(): void
+    {
+        self::assertSame('Anrufen', OrderingPlatform::PHONE->actionLabel());
+        self::assertSame('Zur Webseite', OrderingPlatform::WEBSITE->actionLabel());
+        // Alle übrigen Plattformen fallen auf den Default 'Bestellen' zurück.
+        self::assertSame('Bestellen', OrderingPlatform::UBER_EATS->actionLabel());
+        self::assertSame('Bestellen', OrderingPlatform::OTHER->actionLabel());
+    }
+
+    /**
+     * @return iterable<string, array{OrderingPlatform, ?string}>
+     */
+    public static function logoPathProvider(): iterable
+    {
+        yield 'uber_eats' => [OrderingPlatform::UBER_EATS, 'images/platforms/uber-eats.svg'];
+        yield 'deliveroo' => [OrderingPlatform::DELIVEROO, 'images/platforms/deliveroo.svg'];
+        yield 'just_eat' => [OrderingPlatform::JUST_EAT, 'images/platforms/just-eat.svg'];
+        yield 'wolt' => [OrderingPlatform::WOLT, 'images/platforms/wolt.svg'];
+        yield 'wedely' => [OrderingPlatform::WEDELY, 'images/platforms/wedely.svg'];
+        yield 'goosty' => [OrderingPlatform::GOOSTY, 'images/platforms/goosty.svg'];
+        yield 'phone' => [OrderingPlatform::PHONE, null];
+        yield 'website' => [OrderingPlatform::WEBSITE, null];
+        yield 'other' => [OrderingPlatform::OTHER, null];
+    }
+
+    #[DataProvider('logoPathProvider')]
+    public function testLogoPath(OrderingPlatform $platform, ?string $expected): void
+    {
+        self::assertSame($expected, $platform->logoPath());
+    }
+
+    public function testTransKeys(): void
+    {
+        self::assertSame('ordering_platform.wolt', OrderingPlatform::WOLT->transKey());
+        self::assertSame('ordering_action.phone', OrderingPlatform::PHONE->actionTransKey());
+    }
+}

--- a/tests/Repository/CuisineRepositoryTest.php
+++ b/tests/Repository/CuisineRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\Cuisine;
+use App\Repository\CuisineRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class CuisineRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private CuisineRepository $repo;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->repo = $container->get(CuisineRepository::class);
+    }
+
+    public function testFindOrCreateByNameReturnsExistingBySlug(): void
+    {
+        $existing = (new Cuisine())->setName('Vorhandene Kueche')->setSlug('vorhandene-kueche');
+        $this->em->persist($existing);
+        $this->em->flush();
+
+        $before = $this->repo->count();
+        $found = $this->repo->findOrCreateByName('Vorhandene Kueche');
+
+        self::assertSame($existing->getId(), $found->getId());
+
+        $this->em->flush();
+        self::assertSame($before, $this->repo->count(), 'Es darf kein Duplikat angelegt werden.');
+    }
+
+    public function testFindOrCreateByNameCreatesNewWithAsciiSlug(): void
+    {
+        $cuisine = $this->repo->findOrCreateByName('Crêpes Spezial');
+
+        // findOrCreateByName persistiert, flusht aber nicht selbst.
+        self::assertNull($cuisine->getId());
+        self::assertSame('Crêpes Spezial', $cuisine->getName());
+        self::assertSame('crepes-spezial', $cuisine->getSlug());
+
+        $this->em->flush();
+        self::assertNotNull($cuisine->getId());
+    }
+
+    public function testFindOrCreateByNameIsIdempotent(): void
+    {
+        $name = 'Wiederholbar '.uniqid();
+
+        $first = $this->repo->findOrCreateByName($name);
+        $this->em->flush();
+        $second = $this->repo->findOrCreateByName($name);
+
+        self::assertSame($first->getId(), $second->getId());
+    }
+
+    public function testSearchMatchesByName(): void
+    {
+        $cuisine = (new Cuisine())->setName('Suchmarke ABCXYZ')->setSlug('suchmarke-'.uniqid());
+        $this->em->persist($cuisine);
+        $this->em->flush();
+
+        $results = $this->repo->search('Suchmarke');
+
+        self::assertNotEmpty($results);
+        foreach ($results as $found) {
+            self::assertStringContainsStringIgnoringCase('Suchmarke', $found->getName());
+        }
+    }
+
+    public function testSearchRespectsLimit(): void
+    {
+        self::assertLessThanOrEqual(2, \count($this->repo->search('a', 2)));
+    }
+
+    public function testFindAllSortedIsAscending(): void
+    {
+        $this->em->persist((new Cuisine())->setName('ZZZ Sortprobe')->setSlug('zzz-sortprobe-'.uniqid()));
+        $this->em->persist((new Cuisine())->setName('AAA Sortprobe')->setSlug('aaa-sortprobe-'.uniqid()));
+        $this->em->flush();
+
+        $names = array_map(static fn (Cuisine $c) => $c->getName(), $this->repo->findAllSorted());
+
+        self::assertLessThan(
+            array_search('ZZZ Sortprobe', $names, true),
+            array_search('AAA Sortprobe', $names, true),
+        );
+    }
+}

--- a/tests/Repository/RestaurantImageRepositoryTest.php
+++ b/tests/Repository/RestaurantImageRepositoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\Restaurant;
+use App\Entity\RestaurantImage;
+use App\Repository\RestaurantImageRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class RestaurantImageRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private RestaurantImageRepository $repo;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->repo = $container->get(RestaurantImageRepository::class);
+    }
+
+    private function persistRestaurant(): Restaurant
+    {
+        $restaurant = (new Restaurant())->setName('Bild Probe')->setCity('Luxembourg');
+        $this->em->persist($restaurant);
+        $this->em->flush();
+
+        return $restaurant;
+    }
+
+    public function testNextSortOrderIsOneForEmptyRestaurant(): void
+    {
+        // MAX(sortOrder) ist NULL => 0, +1 => 1 (erstes Bild erhält sortOrder 1).
+        self::assertSame(1, $this->repo->getNextSortOrder($this->persistRestaurant()));
+    }
+
+    public function testNextSortOrderIsMaxPlusOne(): void
+    {
+        $restaurant = $this->persistRestaurant();
+
+        foreach ([1, 4] as $order) {
+            $image = (new RestaurantImage())->setFilename('img-'.$order.'.jpg')->setSortOrder($order);
+            $image->setRestaurant($restaurant);
+            $this->em->persist($image);
+        }
+        $this->em->flush();
+
+        self::assertSame(5, $this->repo->getNextSortOrder($restaurant));
+    }
+}

--- a/tests/Repository/RestaurantRepositoryTest.php
+++ b/tests/Repository/RestaurantRepositoryTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\Cuisine;
+use App\Entity\OpeningHour;
+use App\Entity\Restaurant;
+use App\Entity\User;
+use App\Enum\Language;
+use App\Repository\RestaurantRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Integrationstests gegen echtes MySQL (findPaginated nutzt JSON_CONTAINS).
+ * DAMADoctrineTestBundle rollt jeden Test in einer Transaktion zurück.
+ */
+final class RestaurantRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private RestaurantRepository $repo;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->repo = $container->get(RestaurantRepository::class);
+    }
+
+    private function newRestaurant(string $name, string $city = 'Luxembourg'): Restaurant
+    {
+        return (new Restaurant())->setName($name)->setCity($city);
+    }
+
+    private function persist(object ...$entities): void
+    {
+        foreach ($entities as $entity) {
+            $this->em->persist($entity);
+        }
+        $this->em->flush();
+    }
+
+    /** @return int[] */
+    private function ids(Paginator $paginator): array
+    {
+        return array_map(static fn (Restaurant $r) => $r->getId(), iterator_to_array($paginator));
+    }
+
+    public function testDefaultReturnsAllFixturesAsPaginator(): void
+    {
+        $paginator = $this->repo->findPaginated();
+
+        self::assertInstanceOf(Paginator::class, $paginator);
+        self::assertGreaterThanOrEqual(11, \count($paginator));
+    }
+
+    public function testVerifiedFilter(): void
+    {
+        $paginator = $this->repo->findPaginated('rating', 1, 100, ['verified' => 1]);
+
+        $items = iterator_to_array($paginator);
+        self::assertNotEmpty($items);
+        foreach ($items as $restaurant) {
+            self::assertTrue($restaurant->isVerified());
+        }
+        self::assertSame($this->repo->countVerified(), \count($paginator));
+    }
+
+    public function testSortByNameIsAscending(): void
+    {
+        $this->persist($this->newRestaurant('ZZZ Sortprobe'), $this->newRestaurant('AAA Sortprobe'));
+
+        $names = array_map(
+            static fn (Restaurant $r) => $r->getName(),
+            iterator_to_array($this->repo->findPaginated('name', 1, 200)),
+        );
+
+        self::assertLessThan(
+            array_search('ZZZ Sortprobe', $names, true),
+            array_search('AAA Sortprobe', $names, true),
+        );
+    }
+
+    public function testSortByNewestPutsFreshlyCreatedFirst(): void
+    {
+        $fresh = $this->newRestaurant('Brandneu '.uniqid());
+        $this->persist($fresh);
+
+        $items = iterator_to_array($this->repo->findPaginated('newest', 1, 1));
+
+        self::assertSame($fresh->getId(), $items[0]->getId());
+    }
+
+    public function testPaginationLimitsAndPagesDoNotOverlap(): void
+    {
+        $page1 = $this->repo->findPaginated('name', 1, 5);
+        $page2 = $this->repo->findPaginated('name', 2, 5);
+
+        self::assertLessThanOrEqual(5, iterator_count($page1->getIterator()));
+        self::assertSame([], array_intersect($this->ids($page1), $this->ids($page2)));
+    }
+
+    public function testCityFilterUsesLikeSearch(): void
+    {
+        $mine = $this->newRestaurant('Stadt Probe', 'Wormeldange-Haut');
+        $this->persist($mine);
+
+        $paginator = $this->repo->findPaginated('rating', 1, 100, ['city' => 'Wormeldange']);
+
+        self::assertContains($mine->getId(), $this->ids($paginator));
+        foreach (iterator_to_array($paginator) as $restaurant) {
+            self::assertStringContainsStringIgnoringCase('Wormeldange', $restaurant->getCity());
+        }
+    }
+
+    public function testCuisineFilterJoinsManyToMany(): void
+    {
+        $marker = uniqid();
+        $cuisine = (new Cuisine())->setName('Testküche '.$marker)->setSlug('testkueche-'.$marker);
+
+        $withCuisine = $this->newRestaurant('Mit Küche');
+        $withCuisine->addCuisine($cuisine);
+        $without = $this->newRestaurant('Ohne Küche');
+
+        $this->persist($cuisine, $withCuisine, $without);
+
+        $ids = $this->ids($this->repo->findPaginated('rating', 1, 100, ['cuisine' => [$cuisine->getId()]]));
+
+        self::assertContains($withCuisine->getId(), $ids);
+        self::assertNotContains($without->getId(), $ids);
+    }
+
+    public function testLanguageFilterUsesJsonContains(): void
+    {
+        $mine = $this->newRestaurant('Sprach Probe')->setSpokenLanguages([Language::PT]);
+        $this->persist($mine);
+
+        $paginator = $this->repo->findPaginated('rating', 1, 200, ['lang' => ['pt']]);
+
+        self::assertContains($mine->getId(), $this->ids($paginator));
+        foreach (iterator_to_array($paginator) as $restaurant) {
+            $codes = array_map(static fn (Language $l) => $l->value, $restaurant->getSpokenLanguages());
+            self::assertContains('pt', $codes);
+        }
+    }
+
+    public function testBooleanAccessibilityFilter(): void
+    {
+        $yes = $this->newRestaurant('Rollstuhl Ja')->setIsWheelchairAccessible(true);
+        $no = $this->newRestaurant('Rollstuhl Nein')->setIsWheelchairAccessible(false);
+        $this->persist($yes, $no);
+
+        $ids = $this->ids($this->repo->findPaginated('rating', 1, 200, ['wheelchair' => 1]));
+
+        self::assertContains($yes->getId(), $ids);
+        self::assertNotContains($no->getId(), $ids);
+    }
+
+    public function testOpenFilterIncludesOpenAndExcludesClosed(): void
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Luxembourg'));
+        $today = (int) $now->format('N');
+
+        // Slot 00:00–23:59:59 deckt fast jeden Zeitpunkt von "heute" ab (deterministisch,
+        // unabhängig von der Uhrzeit des Testlaufs; die SQL-Nachtschicht-Logik selbst
+        // wird in OpeningHoursServiceTest gesondert geprüft).
+        $open = $this->newRestaurant('Immer Offen');
+        $open->addOpeningHour(
+            (new OpeningHour())->setDayOfWeek($today)
+                ->setOpenTime(new \DateTime('00:00:00'))
+                ->setCloseTime(new \DateTime('23:59:59'))
+        );
+        $closed = $this->newRestaurant('Ohne Zeiten'); // keine Slots => geschlossen
+
+        $this->persist($open, $closed);
+
+        $ids = $this->ids($this->repo->findPaginated('rating', 1, 200, ['open' => 1]));
+
+        self::assertContains($open->getId(), $ids);
+        self::assertNotContains($closed->getId(), $ids);
+    }
+
+    public function testCombinedFiltersAreAndedTogether(): void
+    {
+        $match = $this->newRestaurant('Alles erfüllt')
+            ->setIsVerified(true)
+            ->setIsWheelchairAccessible(true)
+            ->setIsVegan(true);
+        $partial = $this->newRestaurant('Nur verifiziert')->setIsVerified(true);
+        $this->persist($match, $partial);
+
+        $filters = ['verified' => 1, 'wheelchair' => 1, 'vegan' => 1];
+        $items = iterator_to_array($this->repo->findPaginated('rating', 1, 200, $filters));
+        $ids = array_map(static fn (Restaurant $r) => $r->getId(), $items);
+
+        self::assertContains($match->getId(), $ids);
+        self::assertNotContains($partial->getId(), $ids);
+        foreach ($items as $restaurant) {
+            self::assertTrue($restaurant->isVerified());
+            self::assertTrue($restaurant->isWheelchairAccessible());
+            self::assertTrue($restaurant->isVegan());
+        }
+    }
+
+    public function testFindTopRatedIsLimitedAndDescending(): void
+    {
+        $top = $this->repo->findTopRated(6);
+
+        self::assertLessThanOrEqual(6, \count($top));
+
+        $previous = null;
+        foreach ($top as $restaurant) {
+            $rating = $restaurant->getRating();
+            if ($previous !== null && $rating !== null) {
+                self::assertLessThanOrEqual($previous, $rating);
+            }
+            if ($rating !== null) {
+                $previous = $rating;
+            }
+        }
+    }
+
+    public function testFindBySubmitterReturnsOnlyOwnRestaurants(): void
+    {
+        $user = (new User())
+            ->setName('Einreicher')
+            ->setEmail('einreicher_'.uniqid().'@endlech.lu')
+            ->setPassword('hashed');
+        $r1 = $this->newRestaurant('Eingereicht 1')->setSubmittedBy($user);
+        $r2 = $this->newRestaurant('Eingereicht 2')->setSubmittedBy($user);
+        $foreign = $this->newRestaurant('Fremd');
+
+        $this->persist($user, $r1, $r2, $foreign);
+
+        $result = $this->repo->findBySubmitter($user);
+        $ids = array_map(static fn (Restaurant $r) => $r->getId(), $result);
+
+        self::assertCount(2, $result);
+        self::assertContains($r1->getId(), $ids);
+        self::assertContains($r2->getId(), $ids);
+        self::assertNotContains($foreign->getId(), $ids);
+    }
+
+    public function testCountVerifiedMatchesFixtures(): void
+    {
+        self::assertSame(3, $this->repo->countVerified());
+    }
+
+    public function testCountCreatedSince(): void
+    {
+        self::assertSame(0, $this->repo->countCreatedSince(new \DateTimeImmutable('+1 day')));
+        self::assertGreaterThanOrEqual(11, $this->repo->countCreatedSince(new \DateTimeImmutable('-10 years')));
+    }
+
+    public function testFindRecentIsLimited(): void
+    {
+        self::assertLessThanOrEqual(3, \count($this->repo->findRecent(3)));
+    }
+}

--- a/tests/Repository/RestaurantSuggestionRepositoryTest.php
+++ b/tests/Repository/RestaurantSuggestionRepositoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\RestaurantSuggestion;
+use App\Repository\RestaurantSuggestionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class RestaurantSuggestionRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private RestaurantSuggestionRepository $repo;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->repo = $container->get(RestaurantSuggestionRepository::class);
+    }
+
+    private function persistSuggestion(string $name, string $status): RestaurantSuggestion
+    {
+        $suggestion = (new RestaurantSuggestion())
+            ->setName($name)
+            ->setCity('Luxembourg')
+            ->setCuisine('Test')
+            ->setStatus($status);
+        $this->em->persist($suggestion);
+        $this->em->flush();
+
+        return $suggestion;
+    }
+
+    public function testCountPendingCountsOnlyPending(): void
+    {
+        $before = $this->repo->countPending();
+
+        $this->persistSuggestion('Pending A', RestaurantSuggestion::STATUS_PENDING);
+        $this->persistSuggestion('Pending B', RestaurantSuggestion::STATUS_PENDING);
+        $this->persistSuggestion('Approved', RestaurantSuggestion::STATUS_APPROVED);
+
+        self::assertSame($before + 2, $this->repo->countPending());
+    }
+
+    public function testFindByStatusFiltersAndSortsByCreatedAtDesc(): void
+    {
+        $pending = $this->persistSuggestion('Pending X', RestaurantSuggestion::STATUS_PENDING);
+        $approved = $this->persistSuggestion('Approved Y', RestaurantSuggestion::STATUS_APPROVED);
+
+        $pendingResults = $this->repo->findByStatus(RestaurantSuggestion::STATUS_PENDING);
+        $pendingIds = array_map(static fn (RestaurantSuggestion $s) => $s->getId(), $pendingResults);
+
+        self::assertContains($pending->getId(), $pendingIds);
+        self::assertNotContains($approved->getId(), $pendingIds);
+        foreach ($pendingResults as $suggestion) {
+            self::assertSame(RestaurantSuggestion::STATUS_PENDING, $suggestion->getStatus());
+        }
+
+        $approvedResults = $this->repo->findByStatus(RestaurantSuggestion::STATUS_APPROVED);
+        $approvedIds = array_map(static fn (RestaurantSuggestion $s) => $s->getId(), $approvedResults);
+        self::assertContains($approved->getId(), $approvedIds);
+    }
+}

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class UserRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private UserRepository $repo;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->repo = $container->get(UserRepository::class);
+    }
+
+    private function persistUser(string $email): User
+    {
+        $user = (new User())->setName('Test')->setEmail($email)->setPassword('hashed');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    public function testFindByVerificationToken(): void
+    {
+        $token = 'tok_'.uniqid();
+        $user = $this->persistUser('token_'.uniqid().'@endlech.lu');
+        $user->setVerificationToken($token);
+        $this->em->flush();
+
+        self::assertSame($user->getId(), $this->repo->findByVerificationToken($token)?->getId());
+        self::assertNull($this->repo->findByVerificationToken('nicht-vorhanden'));
+    }
+
+    public function testCountRegisteredSince(): void
+    {
+        self::assertSame(0, $this->repo->countRegisteredSince(new \DateTimeImmutable('+1 day')));
+        self::assertGreaterThanOrEqual(3, $this->repo->countRegisteredSince(new \DateTimeImmutable('-10 years')));
+    }
+
+    public function testFindRecentReturnsNewestFirst(): void
+    {
+        $fresh = $this->persistUser('frisch_'.uniqid().'@endlech.lu');
+
+        $recent = $this->repo->findRecent(1);
+
+        self::assertCount(1, $recent);
+        self::assertSame($fresh->getId(), $recent[0]->getId());
+    }
+}

--- a/tests/Service/AdminStatsServiceTest.php
+++ b/tests/Service/AdminStatsServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Restaurant;
+use App\Entity\User;
+use App\Repository\RestaurantImageRepository;
+use App\Repository\RestaurantRepository;
+use App\Repository\RestaurantSuggestionRepository;
+use App\Repository\UserRepository;
+use App\Service\AdminStatsService;
+use PHPUnit\Framework\TestCase;
+
+final class AdminStatsServiceTest extends TestCase
+{
+    public function testAggregatesDelegateToRepositories(): void
+    {
+        $restaurants = $this->createStub(RestaurantRepository::class);
+        $restaurants->method('count')->willReturn(11);
+        $restaurants->method('countVerified')->willReturn(3);
+
+        $users = $this->createStub(UserRepository::class);
+        $users->method('count')->willReturn(5);
+
+        $images = $this->createStub(RestaurantImageRepository::class);
+        $images->method('count')->willReturn(7);
+
+        $suggestions = $this->createStub(RestaurantSuggestionRepository::class);
+        $suggestions->method('countPending')->willReturn(4);
+
+        $service = new AdminStatsService($restaurants, $users, $images, $suggestions);
+
+        self::assertSame(11, $service->getRestaurantCount());
+        self::assertSame(3, $service->getVerifiedCount());
+        self::assertSame(5, $service->getUserCount());
+        self::assertSame(7, $service->getImageCount());
+        self::assertSame(4, $service->getPendingSuggestionCount());
+    }
+
+    public function testThisMonthCountersUseFirstDayOfMonth(): void
+    {
+        $restaurants = $this->createMock(RestaurantRepository::class);
+        $restaurants->expects(self::once())
+            ->method('countCreatedSince')
+            ->with(self::callback(static function (\DateTimeImmutable $since): bool {
+                return $since->format('d') === '01' && $since->format('H:i:s') === '00:00:00';
+            }))
+            ->willReturn(2);
+
+        $users = $this->createMock(UserRepository::class);
+        $users->expects(self::once())
+            ->method('countRegisteredSince')
+            ->with(self::isInstanceOf(\DateTimeImmutable::class))
+            ->willReturn(1);
+
+        $service = new AdminStatsService(
+            $restaurants,
+            $users,
+            $this->createStub(RestaurantImageRepository::class),
+            $this->createStub(RestaurantSuggestionRepository::class),
+        );
+
+        self::assertSame(2, $service->getRestaurantsAddedThisMonth());
+        self::assertSame(1, $service->getUsersRegisteredThisMonth());
+    }
+
+    public function testRecentListsAreForwardedWithLimit(): void
+    {
+        $recentRestaurants = [new Restaurant(), new Restaurant()];
+        $recentUsers = [new User()];
+
+        $restaurants = $this->createMock(RestaurantRepository::class);
+        $restaurants->expects(self::once())->method('findRecent')->with(5)->willReturn($recentRestaurants);
+
+        $users = $this->createMock(UserRepository::class);
+        $users->expects(self::once())->method('findRecent')->with(3)->willReturn($recentUsers);
+
+        $service = new AdminStatsService(
+            $restaurants,
+            $users,
+            $this->createStub(RestaurantImageRepository::class),
+            $this->createStub(RestaurantSuggestionRepository::class),
+        );
+
+        self::assertSame($recentRestaurants, $service->getRecentRestaurants(5));
+        self::assertSame($recentUsers, $service->getRecentUsers(3));
+    }
+}

--- a/tests/Service/AvatarUploadServiceTest.php
+++ b/tests/Service/AvatarUploadServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\AvatarUploadService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class AvatarUploadServiceTest extends KernelTestCase
+{
+    private const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    private string $uploadDir;
+    private EntityManagerInterface $em;
+    private AvatarUploadService $service;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->uploadDir = sys_get_temp_dir().'/endlech_avatar_'.uniqid();
+        mkdir($this->uploadDir, 0777, true);
+
+        $this->service = new AvatarUploadService($this->uploadDir, $this->em);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->uploadDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->uploadDir);
+        parent::tearDown();
+    }
+
+    private function uploadedPng(): UploadedFile
+    {
+        $source = $this->uploadDir.'/source_'.uniqid().'.png';
+        file_put_contents($source, base64_decode(self::PNG_BASE64));
+
+        return new UploadedFile($source, 'avatar.png', 'image/png', null, true);
+    }
+
+    private function fixtureUser(): User
+    {
+        return static::getContainer()->get(UserRepository::class)->findOneBy(['email' => 'user@endlech.lu']);
+    }
+
+    public function testUploadStoresFileAndSetsFilename(): void
+    {
+        $user = $this->fixtureUser();
+        $user->setAvatarFilename(null);
+
+        $filename = $this->service->upload($this->uploadedPng(), $user);
+
+        self::assertStringEndsWith('.png', $filename);
+        self::assertSame($filename, $user->getAvatarFilename());
+        self::assertFileExists($this->uploadDir.'/'.$filename);
+    }
+
+    public function testUploadDeletesPreviousAvatar(): void
+    {
+        $user = $this->fixtureUser();
+
+        $oldFilename = 'old_'.uniqid().'.png';
+        $oldPath = $this->uploadDir.'/'.$oldFilename;
+        file_put_contents($oldPath, base64_decode(self::PNG_BASE64));
+        $user->setAvatarFilename($oldFilename);
+
+        $newFilename = $this->service->upload($this->uploadedPng(), $user);
+
+        self::assertFileDoesNotExist($oldPath);
+        self::assertNotSame($oldFilename, $newFilename);
+        self::assertFileExists($this->uploadDir.'/'.$newFilename);
+    }
+
+    public function testDeleteRemovesFileAndClearsFilename(): void
+    {
+        $user = $this->fixtureUser();
+
+        $filename = 'avatar_'.uniqid().'.png';
+        $path = $this->uploadDir.'/'.$filename;
+        file_put_contents($path, base64_decode(self::PNG_BASE64));
+        $user->setAvatarFilename($filename);
+
+        $this->service->delete($user);
+
+        self::assertFileDoesNotExist($path);
+        self::assertNull($user->getAvatarFilename());
+    }
+}

--- a/tests/Service/ImageUploadServiceTest.php
+++ b/tests/Service/ImageUploadServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Restaurant;
+use App\Entity\RestaurantImage;
+use App\Repository\RestaurantImageRepository;
+use App\Service\ImageUploadService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class ImageUploadServiceTest extends KernelTestCase
+{
+    // 1×1-PNG; finfo erkennt image/png => guessExtension() liefert 'png' (keine ext-gd nötig).
+    private const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    private string $uploadDir;
+    private EntityManagerInterface $em;
+    private ImageUploadService $service;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->uploadDir = sys_get_temp_dir().'/endlech_img_'.uniqid();
+        mkdir($this->uploadDir, 0777, true);
+
+        $this->service = new ImageUploadService(
+            $this->uploadDir,
+            $this->em,
+            $container->get(RestaurantImageRepository::class),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->uploadDir.'/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->uploadDir);
+        parent::tearDown();
+    }
+
+    private function uploadedPng(): UploadedFile
+    {
+        $source = $this->uploadDir.'/source_'.uniqid().'.png';
+        file_put_contents($source, base64_decode(self::PNG_BASE64));
+
+        return new UploadedFile($source, 'photo.png', 'image/png', null, true);
+    }
+
+    private function persistRestaurant(): Restaurant
+    {
+        $restaurant = (new Restaurant())->setName('Foto Probe')->setCity('Luxembourg');
+        $this->em->persist($restaurant);
+        $this->em->flush();
+
+        return $restaurant;
+    }
+
+    public function testUploadStoresFileAndPersistsImage(): void
+    {
+        $restaurant = $this->persistRestaurant();
+
+        $image = $this->service->upload($this->uploadedPng(), $restaurant);
+
+        self::assertInstanceOf(RestaurantImage::class, $image);
+        self::assertNotNull($image->getId());
+        self::assertStringEndsWith('.png', $image->getFilename());
+        self::assertFileExists($this->uploadDir.'/'.$image->getFilename());
+        self::assertSame(1, $image->getSortOrder());
+        // Leerer Alt-Text fällt auf den Restaurant-Namen zurück.
+        self::assertSame('Foto Probe', $image->getAltText());
+    }
+
+    public function testUploadUsesProvidedAltText(): void
+    {
+        $restaurant = $this->persistRestaurant();
+
+        $image = $this->service->upload($this->uploadedPng(), $restaurant, 'Aussenansicht');
+
+        self::assertSame('Aussenansicht', $image->getAltText());
+    }
+
+    public function testDeleteRemovesFileAndReindexesRemaining(): void
+    {
+        $restaurant = $this->persistRestaurant();
+
+        $first = $this->service->upload($this->uploadedPng(), $restaurant);
+        $middle = $this->service->upload($this->uploadedPng(), $restaurant);
+        $last = $this->service->upload($this->uploadedPng(), $restaurant);
+
+        self::assertSame([1, 2, 3], [$first->getSortOrder(), $middle->getSortOrder(), $last->getSortOrder()]);
+
+        $middlePath = $this->uploadDir.'/'.$middle->getFilename();
+        self::assertFileExists($middlePath);
+
+        $this->service->delete($middle);
+
+        self::assertFileDoesNotExist($middlePath);
+
+        $repo = static::getContainer()->get(RestaurantImageRepository::class);
+        $remaining = $repo->findBy(['restaurant' => $restaurant], ['sortOrder' => 'ASC']);
+
+        self::assertCount(2, $remaining);
+        self::assertSame([0, 1], array_map(static fn (RestaurantImage $i) => $i->getSortOrder(), $remaining));
+    }
+}

--- a/tests/Service/PublicTransportServiceTest.php
+++ b/tests/Service/PublicTransportServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\DTO\NearbyStop;
+use App\Service\PublicTransportService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class PublicTransportServiceTest extends TestCase
+{
+    private function jsonResponse(array $payload): MockResponse
+    {
+        return new MockResponse(
+            json_encode($payload),
+            ['response_headers' => ['Content-Type' => 'application/json']],
+        );
+    }
+
+    /**
+     * @param MockResponse[]|callable $responses
+     */
+    private function service(
+        array|callable $responses = [],
+        string $apiKey = 'TESTKEY',
+        int $radius = 500,
+        int $maxStops = 5,
+        ?LoggerInterface $logger = null,
+    ): PublicTransportService {
+        return new PublicTransportService(
+            new MockHttpClient($responses),
+            new ArrayAdapter(),
+            $logger ?? new NullLogger(),
+            $apiKey,
+            $radius,
+            $maxStops,
+        );
+    }
+
+    public function testEmptyApiKeyReturnsEmptyWithoutHttpCall(): void
+    {
+        // MockHttpClient ohne Responses würde bei jedem Request werfen.
+        $service = $this->service([], apiKey: '');
+
+        self::assertSame([], $service->findNearbyStops('49.6116', '6.1319'));
+    }
+
+    public function testParsesDeduplicatesSortsAndLimits(): void
+    {
+        $service = $this->service([
+            $this->jsonResponse([
+                'stopLocationOrCoordLocation' => [
+                    ['StopLocation' => [
+                        'name' => 'Hamilius',
+                        'dist' => 120,
+                        'products' => 36, // 32 (Bus) | 4 (Tram) => mixed
+                        'productAtStop' => [['name' => '16'], ['name' => '16'], ['name' => 'T1']],
+                    ]],
+                    // Gleicher Name => muss verworfen werden (Dedup, näher, aber später im Array).
+                    ['StopLocation' => ['name' => 'Hamilius', 'dist' => 90, 'products' => 4]],
+                    ['StopLocation' => ['name' => 'Gare Centrale', 'dist' => 300, 'products' => 32]], // bus
+                    ['StopLocation' => ['name' => 'Theater', 'dist' => 50, 'products' => 4]], // tram
+                    ['CoordLocation' => ['name' => 'Ignoriert']], // kein StopLocation => übersprungen
+                ],
+            ]),
+        ]);
+
+        $stops = $service->findNearbyStops('49.6116', '6.1319');
+
+        self::assertCount(3, $stops);
+        self::assertContainsOnlyInstancesOf(NearbyStop::class, $stops);
+
+        // Sortiert nach Distanz aufsteigend.
+        self::assertSame(['Theater', 'Hamilius', 'Gare Centrale'], array_map(fn (NearbyStop $s) => $s->name, $stops));
+        self::assertSame([50, 120, 300], array_map(fn (NearbyStop $s) => $s->distance, $stops));
+
+        // Typ-Ableitung aus Bitflags.
+        self::assertSame('tram', $stops[0]->type);
+        self::assertSame('mixed', $stops[1]->type);
+        self::assertSame('bus', $stops[2]->type);
+
+        // Linien dedupliziert ('16' nur einmal).
+        self::assertSame(['16', 'T1'], $stops[1]->lines);
+    }
+
+    public function testRespectsMaxStopsLimit(): void
+    {
+        $entries = [];
+        for ($i = 1; $i <= 8; ++$i) {
+            $entries[] = ['StopLocation' => ['name' => 'Stop '.$i, 'dist' => $i * 10, 'products' => 32]];
+        }
+
+        $service = $this->service(
+            [$this->jsonResponse(['stopLocationOrCoordLocation' => $entries])],
+            maxStops: 3,
+        );
+
+        self::assertCount(3, $service->findNearbyStops('49.6116', '6.1319'));
+    }
+
+    public function testCachesResultForIdenticalCoordinates(): void
+    {
+        // Nur EINE Response: ein zweiter HTTP-Request würde werfen.
+        $service = $this->service([
+            $this->jsonResponse([
+                'stopLocationOrCoordLocation' => [
+                    ['StopLocation' => ['name' => 'Hamilius', 'dist' => 120, 'products' => 32]],
+                ],
+            ]),
+        ]);
+
+        $first = $service->findNearbyStops('49.6116', '6.1319');
+        $second = $service->findNearbyStops('49.6116', '6.1319');
+
+        self::assertCount(1, $first);
+        self::assertEquals($first, $second);
+    }
+
+    public function testHttpErrorIsLoggedAndReturnsEmpty(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error');
+
+        $service = $this->service([new MockResponse('', ['http_code' => 500])], logger: $logger);
+
+        self::assertSame([], $service->findNearbyStops('49.6116', '6.1319'));
+    }
+
+    public function testPassesApiKeyRadiusAndCoordinatesToRequest(): void
+    {
+        $captured = null;
+        $service = $this->service(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->jsonResponse(['stopLocationOrCoordLocation' => []]);
+        }, apiKey: 'SECRET', radius: 750);
+
+        $service->findNearbyStops('49.6116', '6.1319');
+
+        self::assertNotNull($captured);
+        self::assertStringContainsString('accessId=SECRET', $captured);
+        self::assertStringContainsString('r=750', $captured);
+        self::assertStringContainsString('originCoordLat=49.6116', $captured);
+        self::assertStringContainsString('originCoordLong=6.1319', $captured);
+    }
+}

--- a/tests/Twig/OpeningHoursExtensionTest.php
+++ b/tests/Twig/OpeningHoursExtensionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Tests\Twig;
+
+use App\Entity\Restaurant;
+use App\Service\OpeningHoursService;
+use App\Twig\OpeningHoursExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+final class OpeningHoursExtensionTest extends TestCase
+{
+    public function testRegistersFilterAndFunction(): void
+    {
+        $extension = new OpeningHoursExtension($this->createStub(OpeningHoursService::class));
+
+        $filters = $extension->getFilters();
+        self::assertCount(1, $filters);
+        self::assertInstanceOf(TwigFilter::class, $filters[0]);
+        self::assertSame('is_open_now', $filters[0]->getName());
+
+        $functions = $extension->getFunctions();
+        self::assertCount(1, $functions);
+        self::assertInstanceOf(TwigFunction::class, $functions[0]);
+        self::assertSame('next_opening_time', $functions[0]->getName());
+    }
+
+    public function testIsOpenNowDelegatesToService(): void
+    {
+        $restaurant = new Restaurant();
+        $service = $this->createMock(OpeningHoursService::class);
+        $service->expects(self::once())
+            ->method('isOpenNow')
+            ->with($restaurant)
+            ->willReturn(true);
+
+        $extension = new OpeningHoursExtension($service);
+
+        self::assertTrue($extension->isOpenNow($restaurant));
+    }
+
+    public function testGetNextOpeningTimeDelegatesToService(): void
+    {
+        $restaurant = new Restaurant();
+        $next = ['dayOfWeek' => 3, 'time' => new \DateTime('18:00')];
+
+        $service = $this->createMock(OpeningHoursService::class);
+        $service->expects(self::once())
+            ->method('getNextOpeningTime')
+            ->with($restaurant)
+            ->willReturn($next);
+
+        $extension = new OpeningHoursExtension($service);
+
+        self::assertSame($next, $extension->getNextOpeningTime($restaurant));
+    }
+}


### PR DESCRIPTION
## Überblick

Baut die automatisierte Testabdeckung von **29 auf 146 Tests** (474 Assertions) aus, richtet eine isolierte, wiederholbare Test-Infrastruktur ein und ergänzt CI. Dabei haben die Tests **drei echte Produktions-Bugs** aufgedeckt, die hier mitgefixt werden.

## Test-Infrastruktur (Phase 1)
- **`dama/doctrine-test-bundle`** — Transaction-Rollback pro Test → keine DB-Akkumulation, reihenfolgeunabhängig (zweifach grün verifiziert)
- Mailer im Test auf `sync` geroutet → `assertEmailCount()`/`getMailerMessage()` nutzbar; `.env.test` um `MAILER_DSN`/`MOBILITEIT_API_KEY` ergänzt
- **`make test` / `make test-db-setup`** + `composer test`

## Neue Tests (Phasen 2–4, gespiegelt unter `tests/`)
- **Unit** (`TestCase`): PublicTransportService (MockHttpClient), Restaurant-/UserTransformer, Enums, Twig-Extension, AdminStatsService
- **KernelTestCase** (DAMA-isoliert, echtes MySQL): `RestaurantRepository` (alle 14 `findPaginated`-Filter inkl. Nachtschicht- & `JSON_CONTAINS`-Logik), Cuisine/User/Image/Suggestion-Repos, Image-/AvatarUploadService (Temp-Dir-Isolation)
- **WebTestCase**: Home/Restaurant/Security/Registration/Profile/Community-, Admin-Dashboard/-Restaurant/-Suggestion-Controller + `/api/v1`-Ergänzungen. Basisklasse `tests/AbstractWebTestCase.php` mit Login-/Formular-/CSRF-Helfern

## CI (Phase 5)
- `.github/workflows/ci.yml`: PHPUnit-Job (PHP 8.4 + MySQL-8-Service, JWT-Keypair) + Frontend-Job (`tsc --noEmit`, ESLint) bei jedem Push/PR — beides lokal grün

## 🐞 Bugfixes (von den Tests aufgedeckt)
1. **`?lang_…`-Filter warf 500** — `JSON_CONTAINS` war nie als DQL-Funktion registriert → neue `App\Doctrine\JsonContainsFunction`
2. **Restaurant-Detailseiten warfen 500 ohne Nahverkehrs-API-Key** — `app.mobiliteit_api_key` löste zu `null` statt `''` auf und brach den `string`-Typehint von `PublicTransportService` → Fix via `string:`-Env-Prozessor
3. **Admin-Vorschlag-Detailseite warf 500** — `|u`-Twig-Filter ohne installiertes `twig/string-extra` → Paket nachinstalliert

## Bewusst weggelassen
- Multipart-Profil-Edit-Submit (CSRF wird clientseitig per JS injiziert) und Avatar-Lösch-Happy-Path — die Lösch-/Upload-Logik ist auf Service-Ebene abgedeckt.

## Test
`make test` → **OK (146 tests, 474 assertions)**, zweimal in Folge identisch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)