### PR TITLE
CI: automatische Trigger abschalten (nur noch manuell)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
+# Automatische Trigger (push/PR) abgeschaltet – CI läuft nur noch manuell
+# über "Run workflow" (GitHub-UI) bzw. `gh workflow run ci.yml`.
 on:
-  push:
-    branches: [dev, main]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
## Was

Schaltet die automatischen CI-Trigger ab. Der Workflow `ci.yml` läuft nicht mehr bei jedem Push auf `dev`/`main` oder bei Pull Requests, sondern **nur noch manuell**.

## Änderung

- `on.push` (dev/main) und `on.pull_request` entfernt
- Stattdessen nur noch `on.workflow_dispatch`

Die Jobs (`tests`, `frontend`) bleiben unverändert.

## Manuell starten

- GitHub-UI: *Actions* → *CI* → *Run workflow*
- CLI: `gh workflow run ci.yml`

Reaktivieren der Auto-Trigger jederzeit durch Zurücksetzen des `on:`-Blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)