### PR TITLE
Footer-Version auf 2026.08.06 nachziehen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,15 @@ Defined in `compose.yaml` and `compose.override.yaml`:
 
 The project uses **CalVer** (Calendar Versioning): `vYYYY.MM.DD` (e.g., `v2026.01.13`). See `CHANGELOG.md`.
 
+**Bei jedem Release müssen vier Stellen mitgezogen werden** – sie liegen auseinander und wurden schon mehrfach vergessen (das README-Badge stand zwei Releases lang auf einer alten Version, der Footer eines):
+
+1. `CHANGELOG.md` – `[Unreleased]`-Abschnitt zu `[YYYY.MM.DD] – Titel` schließen **und** das Version-Badge in Zeile 5.
+2. `README.md` – Version-Badge (Format mit `v`-Präfix).
+3. `config/services.yaml` – Parameter `app.version`; wird über `twig.yaml` als `app_version` global gesetzt und in `templates/base.html.twig` im Footer gerendert. **Das ist die einzige Stelle, die Besucher sehen.**
+4. Git-Tag `vYYYY.MM.DD` auf dem Release-Commit in `dev`, danach GitHub-Release (`gh release create`).
+
+Konvention: Release-Commit direkt auf `dev` mit dem Titel `Release vYYYY.MM.DD – Titel`, Tag darauf, anschließend Merge `dev` → `production` (= Deploy).
+
 ## CI
 
 GitHub-Actions-Workflow `.github/workflows/ci.yml` (Trigger: **nur** `workflow_dispatch` – die automatischen Push-/PR-Trigger sind bewusst abgeschaltet, Lauf per „Run workflow" bzw. `gh workflow run ci.yml`):

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,7 +7,9 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    app.version: '2026.06.19'
+    # Wird im Footer als `v{{ app_version }}` gerendert (twig.yaml → globals).
+    # Bei jedem Release mitziehen – zusammen mit den Badges in CHANGELOG.md und README.md.
+    app.version: '2026.08.06'
     # string:-Cast, damit ein leerer/fehlender Key zu '' (nicht null) wird – sonst
     # bricht PublicTransportService (string $apiKey) bei der Graceful-Degradation.
     app.mobiliteit_api_key: '%env(string:default::MOBILITEIT_API_KEY)%'


### PR DESCRIPTION
Der Footer rendert `v{{ app_version }}` aus `config/services.yaml` und zeigte nach dem Release noch `2026.06.19` — die einzige Stelle der Version, die Besucher sehen.

`CLAUDE.md` nennt jetzt alle vier Stellen, die pro Release mitzuziehen sind (CHANGELOG-Abschnitt + Badge, README-Badge, `app.version`, Tag/Release).

Der Tag `v2026.08.06` wurde auf diesen Commit gezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)