### PR TITLE
Sentry: Fehler-Tracking auf Production (nur prod-Env)

### DIFF
--- a/.env
+++ b/.env
@@ -69,6 +69,13 @@ JWT_PASSPHRASE=changeme
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
+###> sentry/sentry-symfony ###
+# Leer = Fehler-Tracking deaktiviert (greift ohnehin nur in prod, siehe config/packages/sentry.yaml).
+# Der echte DSN gehört NICHT hierher – das Repo ist öffentlich. Auf Production in
+# ~/public_html/.env.local eintragen, lokal bei Bedarf in .env.local.
+SENTRY_DSN=
+###< sentry/sentry-symfony ###
+
 # Absolute Basis-URL für Asset-Links der REST-API (Bilder, Avatare).
 # Leer = Scheme+Host des aktuellen Requests. Hinter Proxy/CDN z. B. https://api.endlech.lu setzen.
 APP_API_BASE_URL=''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Alle Änderungen an **Endlech.lu** werden in dieser Datei dokumentiert.
 
 ## [Unreleased]
 
+### Added
+- **Fehler-Tracking mit Sentry:** Fehler auf Production waren bislang unsichtbar – Monolog schrieb nur nach `php://stderr`, wo niemand aktiv hinschaut. `sentry/sentry-symfony` meldet jetzt uncaught Exceptions und Monolog-Records ab `WARNING` an ein Sentry-Projekt in der **EU-Region** (Frankfurt). Das Bundle ist in `config/bundles.php` bewusst **nur für `prod`** registriert: lokale Entwicklung und die Test-Suite kennen die Extension gar nicht und können nichts senden. Der DSN kommt aus `SENTRY_DSN` und wird ausschließlich in der `.env.local` auf dem Server gesetzt – nicht im öffentlichen Repo; ein leerer Wert deaktiviert Sentry lautlos (Muster von `MOBILITEIT_API_KEY`). Datenschutzseitig: `send_default_pii: false` (keine IP-Adressen, Cookies, Header oder Nutzerdaten), `zend.exception_ignore_args` bleibt auf dem PHP-Default `On`, damit keine Funktionsargumente wie Passwörter in Stacktraces landen. 404/405/403/429 sind über `ignore_exceptions` gefiltert, sonst hätte Bot-Traffic die Quota geflutet. Sentry-Releases hängen über `release: 'endlech@%app.version%'` am CalVer-Parameter und ziehen bei jedem Release automatisch mit. Datenschutzerklärung um einen Abschnitt „Fehleranalyse (Sentry)" in allen vier Sprachen ergänzt.
+
 - **Map:** Kartenansicht der Locations. *(geplant)*
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,28 @@ Das `.github/`-Verzeichnis enthält außerdem Issue-Templates (Bug Reports, Feat
 
 Server-Setup (einmalig) und die Waisen-Inventur vor dem ersten Lauf: siehe README → „🚢 Deployment".
 
+## Fehler-Tracking (Sentry)
+
+`sentry/sentry-symfony` 5.x meldet uncaught Exceptions und Monolog-Records ab `WARNING` an ein Sentry-Projekt in der **EU-Region** (`ingest.de.sentry.io`, Frankfurt).
+
+**Nur `prod`.** `config/bundles.php` registriert `SentryBundle` mit `['prod' => true]` – in dev und test existiert die Extension nicht (`debug:config sentry` schlägt dort bewusst fehl). Damit kann weder lokale Entwicklung noch die Test-Suite Daten senden, und `ci.yml` braucht keine Anpassung. Zum lokalen Testen: `php bin/console sentry:test --env=prod` mit temporärem DSN in `.env.local`.
+
+**DSN.** `SENTRY_DSN` steht leer in `.env` (committed) und wird **ausschließlich in der `.env.local` auf dem Server** gesetzt – das Repo ist öffentlich, ein committeter DSN erlaubte Fremden das Einschleusen von Events. Leerer Wert = Sentry lautlos inaktiv (dasselbe Muster wie `MOBILITEIT_API_KEY`); der leere Default in `.env` verhindert zugleich, dass `%env(SENTRY_DSN)%` den Container-Build sprengt. ⚠️ Der Eintrag muss **vor** dem Merge nach `production` auf dem Server stehen, sonst deployt es grün und Sentry bleibt still.
+
+**`config/packages/sentry.yaml`** (alles unter `when@prod`):
+- `release: 'endlech@%app.version%'` – hängt am CalVer-Parameter aus `config/services.yaml` und zieht bei jedem Release automatisch mit (kein fünfter Handgriff in der Release-Checkliste).
+- `send_default_pii: false` – keine IP-Adressen, Cookies, Request-Header oder Nutzerdaten.
+- `enable_logs: true` – **reicht allein nicht**; der Handler muss zusätzlich in `monolog.yaml` registriert sein (das Sentry-Onboarding-Snippet verschweigt das).
+- `ignore_exceptions` filtert 404/405/403/429 – ohne das hätte Bot-Traffic die Quota geflutet. Matching läuft über `is_a($class, $pattern, true)`, greift also auch auf Subklassen und Interfaces.
+
+**Monolog.** `config/packages/monolog.yaml` hat im `when@prod`-Block den Handler `sentry_logs` (`type: service`, `id: Sentry\SentryBundle\Monolog\LogsHandler`) neben `main`/`console`/`deprecation`. Der Service wird in `sentry.yaml` mit `Monolog\Level::Warning` definiert (Monolog 3 – nicht die deprecatete Konstante `Monolog\Logger::WARNING`). Bewusst `LogsHandler` (schickt Sentry-*Logs*) statt `Sentry\Monolog\Handler` (schickt *Issues*) – deshalb bleibt `register_error_listener` aktiv, ohne dass Exceptions doppelt gemeldet werden.
+
+**Kein Eingriff am `ApiExceptionSubscriber` nötig:** Sentrys `ErrorListener` hängt mit Priorität **128** an `kernel.exception`, unser Subscriber mit **10**. Sentry sieht `/api/v1`-Exceptions also, bevor `setResponse()` sie in JSON verwandelt.
+
+**`zend.exception_ignore_args` bleibt auf dem PHP-Default `On`** – entgegen der Sentry-Empfehlung. `Off` würde Funktionsargumente in Stacktraces schreiben, also potenziell Passwörter aus `AuthController`. Das passt nicht zu `send_default_pii: false`.
+
+**Flex-Recipe.** Liegt nur in `recipes-contrib`; wegen `extra.symfony.allow-contrib: false` wird es übersprungen (auch mit `SYMFONY_ALLOW_CONTRIB=1`). Bundle-Eintrag, `sentry.yaml` und der `.env`-Block sind daher von Hand angelegt.
+
 ## Key Files Reference
 
 | File                  | Purpose                                    |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ Ideas for version 2.0 (after the first stable release):
     APP_SECRET=your-secret-here
     # Production only (Brevo):
     # MAILER_DSN=brevo+api://YOUR_API_KEY@default
+    # Production only (Sentry error tracking, prod environment only):
+    # SENTRY_DSN=https://...@...ingest.de.sentry.io/...
     ```
+
+    > **Never commit the Sentry DSN** – this repository is public. It belongs in
+    > the server's `.env.local` only. An empty `SENTRY_DSN` silently disables
+    > error tracking, and the bundle is registered for `prod` only, so local
+    > development and the test suite never send anything.
 
 5.  **Database & fixtures:**
     ```bash
@@ -191,6 +198,11 @@ survives: `.env.local`, `config/jwt/*.pem`, `public/uploads/`, `var/`,
 
 Rollback: push a revert commit to `production`. The next run restores the previous
 state including matching assets, because they live in the same commit.
+
+Error tracking is active on production only. `SENTRY_DSN` must be present in the
+server's `~/public_html/.env.local` **before** the merge — otherwise the deploy
+goes green while Sentry stays silently disabled. Verify afterwards over SSH with
+`php bin/console sentry:test`.
 
 ### One-time server setup
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "nelmio/cors-bundle": "^2.6",
         "phpdocumentor/reflection-docblock": "^6.0",
         "phpstan/phpdoc-parser": "^2.3",
+        "sentry/sentry-symfony": "^5.12",
         "symfony/apache-pack": "*",
         "symfony/asset": "8.0.*",
         "symfony/brevo-mailer": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fddabe5ad9307839e0fca2f5f6f560cf",
+    "content-hash": "3bcb6a417f9c219644fe5dcc2b5eee24",
     "packages": [
         {
             "name": "composer/semver",
@@ -1264,6 +1264,185 @@
             "time": "2025-03-06T22:45:56+00:00"
         },
         {
+            "name": "guzzlehttp/psr7",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^2.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.1",
+                "psr/http-message-implementation": "2.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "php-http/psr7-integration-tests": "^1.5.1",
+                "phpunit/phpunit": "^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-20T13:48:31+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
             "name": "lcobucci/jwt",
             "version": "5.6.0",
             "source": {
@@ -2225,6 +2404,114 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/link",
             "version": "2.0.1",
             "source": {
@@ -2391,6 +2678,204 @@
                 "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
             },
             "time": "2026-03-06T22:40:29+00:00"
+        },
+        {
+            "name": "sentry/sentry",
+            "version": "4.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "95a26e7c946651cacd69d1ded95a8190f952a3ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/95a26e7c946651cacd69d1ded95a8190f952a3ae",
+                "reference": "95a26e7c946651cacd69d1ded95a8190f952a3ae",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/psr7": "^1.8.4|^2.1.1|^3.0.0",
+                "jean85/pretty-package-versions": "^1.5|^2.0.4",
+                "php": "^7.2|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "carthage-software/mago": "1.30.0",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "guzzlehttp/guzzle": "^7.0|^8.0",
+                "guzzlehttp/promises": "^2.0.3|^3.0.0",
+                "monolog/monolog": "^1.6|^2.0|^3.0",
+                "nyholm/psr7": "^1.8",
+                "open-telemetry/api": "^1.1",
+                "open-telemetry/context": "^1.1",
+                "open-telemetry/exporter-otlp": "^1.1",
+                "open-telemetry/sdk": "^1.1",
+                "open-telemetry/sem-conv": "^1.27",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^8.5.52|^9.6.34",
+                "spiral/roadrunner-http": "^3.6",
+                "spiral/roadrunner-worker": "^3.6"
+            },
+            "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+                "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Sentry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sentry",
+                    "email": "accounts@sentry.io"
+                }
+            ],
+            "description": "PHP SDK for Sentry (http://sentry.io)",
+            "homepage": "http://sentry.io",
+            "keywords": [
+                "crash-reporting",
+                "crash-reports",
+                "error-handler",
+                "error-monitoring",
+                "log",
+                "logging",
+                "profiling",
+                "sentry",
+                "tracing"
+            ],
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-php/issues",
+                "source": "https://github.com/getsentry/sentry-php/tree/4.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-08-05T14:54:26+00:00"
+        },
+        {
+            "name": "sentry/sentry-symfony",
+            "version": "5.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-symfony.git",
+                "reference": "20786d4d1d7aa35d4b695a6bba14924c8e596370"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-symfony/zipball/20786d4d1d7aa35d4b695a6bba14924c8e596370",
+                "reference": "20786d4d1d7aa35d4b695a6bba14924c8e596370",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.1.1|^3.0",
+                "jean85/pretty-package-versions": "^1.5||^2.0",
+                "php": "^7.2||^8.0",
+                "sentry/sentry": "^4.23.0",
+                "symfony/cache-contracts": "^1.1||^2.4||^3.0",
+                "symfony/config": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/console": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/dependency-injection": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/event-dispatcher": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/http-kernel": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/polyfill-php80": "^1.22",
+                "symfony/psr-http-message-bridge": "^1.2||^2.0||^6.4||^7.0||^8.0",
+                "symfony/yaml": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.13||^3.3||^4.0",
+                "doctrine/doctrine-bundle": "^2.6||^3.0",
+                "friendsofphp/php-cs-fixer": "^2.19||^3.40",
+                "masterminds/html5": "^2.8",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "1.12.5",
+                "phpstan/phpstan-phpunit": "1.4.0",
+                "phpstan/phpstan-symfony": "1.4.10",
+                "phpunit/phpunit": "^8.5.52||^9.6.34",
+                "symfony/browser-kit": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/cache": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/dom-crawler": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/framework-bundle": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/http-client": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/messenger": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/monolog-bundle": "^3.4||^4.0",
+                "symfony/phpunit-bridge": "^5.2.6||^6.0||^7.0||^8.0",
+                "symfony/process": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/security-core": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/security-http": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "symfony/twig-bundle": "^4.4.20||^5.0.11||^6.0||^7.0||^8.0",
+                "vimeo/psalm": "^4.3||^5.16.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "Allow distributed tracing of database queries using Sentry.",
+                "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler.",
+                "symfony/cache": "Allow distributed tracing of cache pools using Sentry.",
+                "symfony/twig-bundle": "Allow distributed tracing of Twig template rendering using Sentry."
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "files": [
+                    "src/aliases.php"
+                ],
+                "psr-4": {
+                    "Sentry\\SentryBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sentry",
+                    "email": "accounts@sentry.io"
+                }
+            ],
+            "description": "Symfony integration for Sentry (http://getsentry.com)",
+            "homepage": "http://getsentry.com",
+            "keywords": [
+                "errors",
+                "logging",
+                "sentry",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-symfony/issues",
+                "source": "https://github.com/getsentry/sentry-symfony/tree/5.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-08-06T11:43:28+00:00"
         },
         {
             "name": "symfony/apache-pack",
@@ -6034,6 +6519,93 @@
                 }
             ],
             "time": "2025-12-18T11:23:51+00:00"
+        },
+        {
+            "name": "symfony/psr-http-message-bridge",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/psr-http-message-bridge.git",
+                "reference": "94facc221260c1d5f20e31ee43cd6c6a824b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/94facc221260c1d5f20e31ee43cd6c6a824b4a19",
+                "reference": "94facc221260c1d5f20e31ee43cd6c6a824b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/http-message": "^1.0|^2.0",
+                "symfony/http-foundation": "^7.4|^8.0"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.1",
+                "php-http/discovery": "^1.15",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\PsrHttpMessage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "PSR HTTP message bridge",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/rate-limiter",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -20,4 +20,5 @@ return [
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
 ];

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -53,3 +53,7 @@ when@prod:
                 channels: [deprecation]
                 path: php://stderr
                 formatter: monolog.formatter.json
+            # Strukturierte Logs ab WARNING an Sentry (Service + Level: sentry.yaml).
+            sentry_logs:
+                type: service
+                id: Sentry\SentryBundle\Monolog\LogsHandler

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -1,0 +1,36 @@
+# Fehler-Tracking nur in Production – das Bundle ist in config/bundles.php ebenfalls
+# nur für prod registriert, dev und test kennen die Extension gar nicht.
+# Leerer SENTRY_DSN = Sentry inaktiv, analog zum Muster von MOBILITEIT_API_KEY
+# in config/services.yaml. Der echte DSN steht in der .env.local auf dem Server.
+when@prod:
+    sentry:
+        dsn: '%env(SENTRY_DSN)%'
+        options:
+            # Koppelt Sentry-Releases an die CalVer-Version aus config/services.yaml.
+            # Wird beim Release automatisch mitgezogen – kein zusätzlicher Handgriff.
+            release: 'endlech@%app.version%'
+            # Keine IP-Adressen, Cookies, Request-Header oder User-Daten an Sentry.
+            send_default_pii: false
+            # Strukturierte Logs aktivieren; den passenden Handler registriert
+            # config/packages/monolog.yaml (enable_logs allein reicht nicht).
+            enable_logs: true
+            # 4xx sind Bot-/Nutzerrauschen, keine Bugs. Das Matching läuft über
+            # is_a($class, $pattern, true), greift also auch auf Subklassen.
+            ignore_exceptions:
+                - 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException'
+                - 'Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException'
+                - 'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException'
+                - 'Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException'
+                - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'
+                - 'Symfony\Component\Security\Core\Exception\AuthenticationException'
+                - 'Symfony\Component\ErrorHandler\Error\FatalError'
+
+    services:
+        # Schickt Log-Records als Sentry-"Logs", nicht als Issues. Weil dieser Handler
+        # keine Issues erzeugt, bleibt register_error_listener aktiv – anders als bei
+        # Sentry\Monolog\Handler, der Exceptions doppelt melden würde.
+        # Level bewusst WARNING: der Handler hängt neben dem fingers_crossed-Handler
+        # und sieht jeden Record direkt; INFO würde die Quota fluten.
+        Sentry\SentryBundle\Monolog\LogsHandler:
+            arguments:
+                - !php/const Monolog\Level::Warning

--- a/config/reference.php
+++ b/config/reference.php
@@ -1650,6 +1650,90 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     enable_static_query_cache?: bool|Param, // Default: true
  *     connection_keys?: list<mixed>,
  * }
+ * @psalm-type SentryConfig = array{
+ *     dsn?: scalar|null|Param, // If this value is not provided, the SDK will try to read it from the SENTRY_DSN environment variable. If that variable also does not exist, the SDK will not send any events.
+ *     register_error_listener?: bool|Param, // Default: true
+ *     register_error_handler?: bool|Param, // Default: true
+ *     logger?: scalar|null|Param, // The service ID of the PSR-3 logger used to log messages coming from the SDK client. Be aware that setting the same logger of the application may create a circular loop when an event fails to be sent. // Default: null
+ *     options?: array{
+ *         integrations?: mixed, // Default: []
+ *         default_integrations?: bool|Param,
+ *         prefixes?: list<scalar|null|Param>,
+ *         sample_rate?: float|Param, // The sampling factor to apply to events. A value of 0 will deny sending any event, and a value of 1 will send all events.
+ *         enable_tracing?: bool|Param,
+ *         traces_sample_rate?: float|Param, // The sampling factor to apply to transactions. A value of 0 will deny sending any transaction, and a value of 1 will send all transactions.
+ *         traces_sampler?: scalar|null|Param,
+ *         profiles_sample_rate?: float|Param, // The sampling factor to apply to profiles. A value of 0 will deny sending any profiles, and a value of 1 will send all profiles. Profiles are sampled in relation to traces_sample_rate
+ *         enable_logs?: bool|Param,
+ *         log_flush_threshold?: mixed, // Default: null
+ *         enable_metrics?: bool|Param, // Default: true
+ *         attach_stacktrace?: bool|Param,
+ *         attach_metric_code_locations?: bool|Param,
+ *         context_lines?: int|Param,
+ *         environment?: scalar|null|Param, // Default: "%kernel.environment%"
+ *         logger?: scalar|null|Param,
+ *         spotlight?: bool|Param,
+ *         spotlight_url?: scalar|null|Param,
+ *         release?: scalar|null|Param, // Default: "%env(default::SENTRY_RELEASE)%"
+ *         org_id?: int|Param,
+ *         server_name?: scalar|null|Param,
+ *         ignore_exceptions?: list<scalar|null|Param>,
+ *         ignore_transactions?: list<scalar|null|Param>,
+ *         before_send?: scalar|null|Param,
+ *         before_send_transaction?: scalar|null|Param,
+ *         before_send_check_in?: scalar|null|Param,
+ *         before_send_metrics?: scalar|null|Param,
+ *         before_send_log?: scalar|null|Param,
+ *         before_send_metric?: scalar|null|Param,
+ *         trace_propagation_targets?: mixed,
+ *         strict_trace_continuation?: bool|Param,
+ *         tags?: array<string, scalar|null|Param>,
+ *         error_types?: scalar|null|Param,
+ *         max_breadcrumbs?: int|Param,
+ *         before_breadcrumb?: mixed,
+ *         in_app_exclude?: list<scalar|null|Param>,
+ *         in_app_include?: list<scalar|null|Param>,
+ *         send_default_pii?: bool|Param,
+ *         max_value_length?: int|Param,
+ *         transport?: scalar|null|Param,
+ *         http_client?: scalar|null|Param,
+ *         http_proxy?: scalar|null|Param,
+ *         http_proxy_authentication?: scalar|null|Param,
+ *         http_connect_timeout?: float|Param, // The maximum number of seconds to wait while trying to connect to a server. It works only when using the default transport.
+ *         http_timeout?: float|Param, // The maximum execution time for the request+response as a whole. It works only when using the default transport.
+ *         http_ssl_verify_peer?: bool|Param,
+ *         http_compression?: bool|Param,
+ *         capture_silenced_errors?: bool|Param,
+ *         max_request_body_size?: "none"|"never"|"small"|"medium"|"always"|Param,
+ *         class_serializers?: array<string, scalar|null|Param>,
+ *     },
+ *     messenger?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         capture_soft_fails?: bool|Param, // Default: true
+ *         isolate_breadcrumbs_by_message?: bool|Param, // Default: false
+ *         isolate_context_by_message?: bool|Param, // Default: false
+ *     },
+ *     tracing?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         dbal?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *             ignore_prepare_spans?: bool|Param, // Default: false
+ *             connections?: list<scalar|null|Param>,
+ *         },
+ *         twig?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *         },
+ *         cache?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *         },
+ *         http_client?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *         },
+ *         console?: array{
+ *             excluded_commands?: list<scalar|null|Param>,
+ *         },
+ *     },
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1708,6 +1792,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *         nelmio_cors?: NelmioCorsConfig,
  *         nelmio_api_doc?: NelmioApiDocConfig,
+ *         sentry?: SentryConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,

--- a/symfony.lock
+++ b/symfony.lock
@@ -104,6 +104,15 @@
             "bin/phpunit"
         ]
     },
+    "sentry/sentry-symfony": {
+        "version": "5.12",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "5.0",
+            "ref": "aac2bc5220e9ab5b9e3838a7a4da90e7f74e6148"
+        }
+    },
     "symfony/apache-pack": {
         "version": "1.0",
         "recipe": {

--- a/templates/impressum/index.html.twig
+++ b/templates/impressum/index.html.twig
@@ -34,8 +34,12 @@
 
     <section id="datenschutz" class="mb-8 scroll-mt-24">
         <h2 class="text-xl font-semibold text-gray-800 mb-3">{{ 'legal.privacy_title'|trans }}</h2>
-        <p class="text-gray-600 leading-relaxed">
+        <p class="text-gray-600 leading-relaxed mb-4">
             {{ 'legal.privacy_text'|trans }}
+        </p>
+        <h3 class="text-base font-semibold text-gray-700 mb-2">{{ 'legal.error_tracking_title'|trans }}</h3>
+        <p class="text-gray-600 leading-relaxed">
+            {{ 'legal.error_tracking_text'|trans }}
         </p>
     </section>
 </div>

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -317,6 +317,8 @@ legal:
     links_text: "Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich."
     privacy_title: "Datenschutz"
     privacy_text: "Die Nutzung unserer Webseite ist in der Regel ohne Angabe personenbezogener Daten möglich. Soweit auf unseren Seiten personenbezogene Daten (beispielsweise Name, Anschrift oder E-Mail-Adressen) erhoben werden, erfolgt dies, soweit möglich, stets auf freiwilliger Basis."
+    error_tracking_title: "Fehleranalyse (Sentry)"
+    error_tracking_text: "Zur Erkennung und Behebung technischer Fehler nutzen wir Sentry (Functional Software, Inc.). Tritt auf unserer Webseite ein Fehler auf, werden technische Angaben wie Zeitpunkt, aufgerufene Seite und Fehlermeldung an Server in der Europäischen Union (Frankfurt am Main) übermittelt. IP-Adressen und Nutzerdaten werden dabei nicht übertragen. Rechtsgrundlage ist unser berechtigtes Interesse an einem stabilen und sicheren Betrieb der Webseite gemäß Art. 6 Abs. 1 lit. f DSGVO."
 
 criteria:
     title: "Kriterien für Barrierefreiheit – Endlech.lu"

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -317,6 +317,8 @@ legal:
     links_text: "Our website contains links to external third-party websites over whose content we have no influence. Therefore, we cannot accept any liability for this external content. The respective provider or operator of the pages is always responsible for the content of the linked pages."
     privacy_title: "Privacy"
     privacy_text: "The use of our website is generally possible without providing personal data. Insofar as personal data (e.g., name, address, or email addresses) is collected on our pages, this is always done on a voluntary basis as far as possible."
+    error_tracking_title: "Error tracking (Sentry)"
+    error_tracking_text: "To detect and fix technical errors, we use Sentry (Functional Software, Inc.). If an error occurs on our website, technical details such as the time, the page requested and the error message are transmitted to servers in the European Union (Frankfurt am Main). IP addresses and user data are not transmitted. The legal basis is our legitimate interest in the stable and secure operation of the website pursuant to Art. 6(1)(f) GDPR."
 
 criteria:
     title: "Accessibility Criteria – Endlech.lu"

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -317,6 +317,8 @@ legal:
     links_text: "Notre site contient des liens vers des sites web externes de tiers sur le contenu desquels nous n'avons aucune influence. Par conséquent, nous ne pouvons assumer aucune responsabilité pour ce contenu externe. Le fournisseur ou l'exploitant respectif des pages est toujours responsable du contenu des pages liées."
     privacy_title: "Protection des données"
     privacy_text: "L'utilisation de notre site web est généralement possible sans fournir de données personnelles. Dans la mesure où des données personnelles (par exemple nom, adresse ou adresses e-mail) sont collectées sur nos pages, cela se fait toujours sur une base volontaire dans la mesure du possible."
+    error_tracking_title: "Analyse des erreurs (Sentry)"
+    error_tracking_text: "Afin de détecter et de corriger les erreurs techniques, nous utilisons Sentry (Functional Software, Inc.). En cas d'erreur sur notre site web, des informations techniques telles que l'heure, la page consultée et le message d'erreur sont transmises à des serveurs situés dans l'Union européenne (Francfort-sur-le-Main). Les adresses IP et les données des utilisateurs ne sont pas transmises. La base juridique est notre intérêt légitime à assurer un fonctionnement stable et sûr du site web conformément à l'art. 6, par. 1, point f) du RGPD."
 
 criteria:
     title: "Critères d'accessibilité – Endlech.lu"

--- a/translations/messages.lb.yaml
+++ b/translations/messages.lb.yaml
@@ -317,6 +317,8 @@ legal:
     links_text: "Eist Ugebot enthält Linken op extern Websäite vu Drëtten, op deenen hiren Inhalt mir keen Afloss hunn. Dofir kënne mir fir dës friem Inhalter och keng Garantie iwwerhuelen. Fir d'Inhalter vun de verlinkten Säiten ass ëmmer den jeweilegen Ubidder oder Bedreiwer vun de Säite verantwortlech."
     privacy_title: "Dateschutz"
     privacy_text: "D'Benotzung vun eiser Websäit ass an der Reegel ouni Ugab vu personebezunnenen Daten méiglech. Soubal op eise Säite personebezunnen Daten (zum Beispill Numm, Adress oder E-Mail-Adressen) erhuewe ginn, geschitt dat, soubal méiglech, ëmmer op fräiwëlleger Basis."
+    error_tracking_title: "Feeleranalyse (Sentry)"
+    error_tracking_text: "Fir technesch Feeler z'erkennen an ze behiewen, notze mir Sentry (Functional Software, Inc.). Wann op eiser Websäit e Feeler optrëtt, ginn technesch Uginne wéi Zäitpunkt, opgeruffe Säit a Feelermeldung u Serveren an der Europäescher Unioun (Frankfurt um Main) iwwerdroen. IP-Adressen an Notzerdate ginn dobäi net iwwerdroen. Rechtsgrondlag ass eise berechtegten Interessi un engem stabilen a séchere Betrib vun der Websäit no Art. 6 Abs. 1 lit. f DSGVO."
 
 criteria:
     title: "Critèren fir Barrierefreiheet – Endlech.lu"


### PR DESCRIPTION
## Warum

Fehler auf Production waren bislang unsichtbar – Monolog schrieb im `when@prod`-Block nur nach `php://stderr`, wo niemand aktiv hinschaut. `sentry/sentry-symfony` meldet jetzt uncaught Exceptions und Monolog-Records ab `WARNING` an ein Sentry-Projekt in der **EU-Region** (Frankfurt).

## Was drin ist

- **Nur `prod`.** Das Bundle ist in `config/bundles.php` mit `['prod' => true]` registriert – dev und test kennen die Extension gar nicht und können nichts senden. `ci.yml` braucht deshalb keine Anpassung.
- **`config/packages/sentry.yaml`** (neu): `release: 'endlech@%app.version%'` hängt am CalVer-Parameter und zieht bei jedem Release automatisch mit; `send_default_pii: false`; `enable_logs: true`; `ignore_exceptions` filtert 404/405/403/429.
- **`config/packages/monolog.yaml`**: Handler `sentry_logs` im `when@prod`-Block.
- **Datenschutzerklärung** um einen Abschnitt „Fehleranalyse (Sentry)" ergänzt – in allen vier Sprachen.
- **Doku**: CHANGELOG (`[Unreleased]`), CLAUDE.md (neuer Abschnitt), README (Env-Var + Deployment-Hinweis).

## Entscheidungen, die eine Erklärung verdienen

- **Der DSN steht nicht im Repo.** `SENTRY_DSN` ist in `.env` leer und wird ausschließlich in der `.env.local` auf dem Server gesetzt – dieses Repo ist öffentlich, ein committeter DSN erlaubte Fremden das Einschleusen von Events. Ein leerer Wert deaktiviert Sentry lautlos (Muster von `MOBILITEIT_API_KEY`); der leere Default verhindert zugleich, dass `%env(SENTRY_DSN)%` den Container-Build sprengt.
- **`zend.exception_ignore_args` bleibt auf dem PHP-Default `On`**, entgegen der Sentry-Empfehlung. `Off` würde Funktionsargumente in Stacktraces schreiben, also potenziell Passwörter aus `AuthController`. Das passt nicht zu `send_default_pii: false`.
- **`ignore_exceptions` statt alles melden:** ohne den Filter hätte Bot-Traffic mit 404ern die Quota geflutet. Matching läuft über `is_a(..., strict: true)`, greift also auch auf Subklassen und Interfaces.
- **`enable_logs: true` reicht allein nicht** – der `LogsHandler` muss zusätzlich in `monolog.yaml` registriert sein; das Sentry-Onboarding-Snippet verschweigt das. Bewusst `LogsHandler` (schickt Sentry-*Logs*) statt `Sentry\Monolog\Handler` (schickt *Issues*), damit Exceptions nicht doppelt gemeldet werden.
- **Kein Eingriff am `ApiExceptionSubscriber` nötig:** Sentrys `ErrorListener` hängt mit Priorität **128** an `kernel.exception`, unser Subscriber mit **10** – `/api/v1`-Exceptions werden also erfasst, bevor `setResponse()` sie in JSON verwandelt.
- **Das contrib-Recipe wird übersprungen** (`allow-contrib: false` sticht auch `SYMFONY_ALLOW_CONTRIB=1`). Bundle-Eintrag, `sentry.yaml` und der `.env`-Block sind daher von Hand angelegt – in genau der Form, die das Recipe erzeugt hätte.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `php bin/phpunit` | 154 Tests, 544 Assertions, grün (strict mode, keine neuen Deprecations) |
| `debug:config sentry --env=prod` | `release: endlech@2026.08.06`, `send_default_pii: false`, `environment: prod` |
| `sentry:test --env=prod` | Message erfolgreich gesendet |
| Leerer DSN | „No DSN configured" – kein Crash |
| dev / test | Extension existiert dort nicht, 0 Sentry-Services |
| HTTP in `prod` (`/de/legal`, `/de/about`, `/fr/legal`) | 200, neuer Datenschutz-Abschnitt wird gerendert |

Keine Änderung unter `assets/` → `public/build` unberührt, der `verify-assets`-Job im CD-Workflow ist nicht betroffen.

## ⚠️ Vor dem Merge nach `production`

`SENTRY_DSN` muss in `~/public_html/.env.local` auf dem Server stehen – sonst läuft der Deploy grün durch und Sentry bleibt stumm. Danach über SSH mit `php bin/console sentry:test` gegenprüfen.

## Nicht enthalten (bewusst)

Performance-Tracing/Profiling und das Browser-SDK (`@sentry/browser`) – JS-Fehler bleiben also unsichtbar. Cookie-Consent-Kopplung entfällt: Sentry läuft rein serverseitig, setzt keine Cookies und erhält wegen `send_default_pii: false` keine personenbezogenen Daten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)